### PR TITLE
Fix adding train bug

### DIFF
--- a/src/TrackEasy.Application/Operators/AddTrain/AddTrainCommandHandler.cs
+++ b/src/TrackEasy.Application/Operators/AddTrain/AddTrainCommandHandler.cs
@@ -16,7 +16,6 @@ public sealed class AddTrainCommandHandler(IOperatorRepository operatorRepositor
         }
 
         operatorEntity.AddTrain(request.Name, request.Coaches);
-        operatorRepository.Add(operatorEntity);
         await operatorRepository.SaveChangesAsync(cancellationToken);
 
         return operatorEntity.Trains.First(x => x.Name == request.Name).Id;


### PR DESCRIPTION
## Summary
- don't re-add an existing operator when adding a train

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683fc855e6c0832a85c1ad911b943b4c