### PR TITLE
Add OpenAPI metadata to ticket endpoints

### DIFF
--- a/src/TrackEasy.Api/Endpoints/TicketEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/TicketEndpoints.cs
@@ -9,6 +9,7 @@ using TrackEasy.Application.Tickets.GetTicketCities;
 using TrackEasy.Application.Tickets.GetTickets;
 using TrackEasy.Application.Tickets.PayTicketByCard;
 using TrackEasy.Application.Tickets.PayTicketByCash;
+using TrackEasy.Shared.Pagination.Abstractions;
 
 namespace TrackEasy.Api.Endpoints;
 
@@ -18,28 +19,38 @@ public class TicketEndpoints : IEndpoints
     {
         var group = rootGroup.MapGroup("tickets").WithTags("Tickets");
         
-        group.MapPost("/", async (BuyTicketCommand command, ISender sender, CancellationToken ct) => 
+        group.MapPost("/", async (BuyTicketCommand command, ISender sender, CancellationToken ct) =>
             Results.Ok(await sender.Send(command, ct)))
             .WithName("BuyTicket")
-            .WithDescription("Purchase tickets for specified connections");
+            .Produces<IReadOnlyCollection<Guid>>()
+            .Produces(StatusCodes.Status400BadRequest)
+            .WithDescription("Purchase tickets for specified connections")
+            .WithOpenApi();
         
-        group.MapGet("/{userId:guid}", async (Guid userId, int pageNumber, int pageSize, TicketType type, ISender sender, CancellationToken ct) => 
+        group.MapGet("/{userId:guid}", async (Guid userId, int pageNumber, int pageSize, TicketType type, ISender sender, CancellationToken ct) =>
             Results.Ok(await sender.Send(new GetTicketsQuery(userId, type, pageNumber, pageSize), ct)))
             .WithName("GetTickets")
-            .WithDescription("Get paginated tickets for a user");
+            .Produces<PaginatedResult<TicketDto>>()
+            .WithDescription("Get paginated tickets for a user")
+            .WithOpenApi();
         
-        group.MapGet("/{ticketId:guid}/details", async (Guid ticketId, ISender sender, CancellationToken ct) => 
+        group.MapGet("/{ticketId:guid}/details", async (Guid ticketId, ISender sender, CancellationToken ct) =>
         {
             var result = await sender.Send(new FindTicketQuery(ticketId), ct);
             return result is not null ? Results.Ok(result) : Results.NotFound();
         })
             .WithName("GetTicketDetails")
-            .WithDescription("Get details of a specific ticket");
+            .Produces<TicketDetailsDto>()
+            .Produces(StatusCodes.Status404NotFound)
+            .WithDescription("Get details of a specific ticket")
+            .WithOpenApi();
         
-        group.MapGet("/{id:guid}/cities", async (Guid id, ISender sender, CancellationToken ct) => 
+        group.MapGet("/{id:guid}/cities", async (Guid id, ISender sender, CancellationToken ct) =>
             Results.Ok(await sender.Send(new GetTicketCitiesQuery(id), ct)))
             .WithName("GetTicketCities")
-            .WithDescription("Get cities related to a ticket");
+            .Produces<IEnumerable<TicketCityDto>>()
+            .WithDescription("Get cities related to a ticket")
+            .WithOpenApi();
         
         group.MapGet("/qr-code/{qrCodeId:guid}", async (Guid qrCodeId, ISender sender, CancellationToken ct) =>
         {
@@ -47,23 +58,32 @@ public class TicketEndpoints : IEndpoints
             return qrCode is not null ? Results.File(qrCode.Content, qrCode.ContentType) : Results.NotFound();
         })
         .WithName("GetTicketQrCode")
-        .WithDescription("Get the QR code for a ticket by its ID");
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound)
+        .WithDescription("Get the QR code for a ticket by its ID")
+        .WithOpenApi();
         
-        group.MapPost("/payment/card", async (PayTicketByCardCommand command, ISender sender, CancellationToken ct) => 
+        group.MapPost("/payment/card", async (PayTicketByCardCommand command, ISender sender, CancellationToken ct) =>
         {
             await sender.Send(command, ct);
             return Results.NoContent();
         })
             .WithName("PayTicketsByCard")
-            .WithDescription("Pay for tickets using card");
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .WithDescription("Pay for tickets using card")
+            .WithOpenApi();
         
-        group.MapPost("/payment/cash/{ticketId:guid}", async (Guid ticketId, ISender sender, CancellationToken ct) => 
+        group.MapPost("/payment/cash/{ticketId:guid}", async (Guid ticketId, ISender sender, CancellationToken ct) =>
         {
             await sender.Send(new PayTicketByCashCommand(ticketId), ct);
             return Results.NoContent();
         })
             .WithName("PayTicketByCash")
-            .WithDescription("Pay for a ticket with cash");
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .WithDescription("Pay for a ticket with cash")
+            .WithOpenApi();
         
         group.MapGet("/current", async (ISender sender, CancellationToken ct) =>
         {
@@ -71,7 +91,10 @@ public class TicketEndpoints : IEndpoints
             return ticketId is not null ? Results.Ok(ticketId) : Results.NotFound();
         })
             .WithName("GetCurrentTicketId")
-            .WithDescription("Get the ID of the current ticket for the user");
+            .Produces<Guid>()
+            .Produces(StatusCodes.Status404NotFound)
+            .WithDescription("Get the ID of the current ticket for the user")
+            .WithOpenApi();
         
         group.MapPost("/refund-request",
             async (CreateRefundRequestCommand command, ISender sender, CancellationToken ct) =>
@@ -80,7 +103,10 @@ public class TicketEndpoints : IEndpoints
                 return Results.NoContent();
             })
             .WithName("CreateRefundRequest")
-            .WithDescription("Create a refund request for a ticket");
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .WithDescription("Create a refund request for a ticket")
+            .WithOpenApi();
             
         group.MapPost("/{ticketId:guid}/cancel",
             async (Guid ticketId, ISender sender, CancellationToken ct) =>
@@ -89,6 +115,9 @@ public class TicketEndpoints : IEndpoints
                 return Results.NoContent();
             })
             .WithName("CancelTicket")
-            .WithDescription("Cancel a ticket by its ID");
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .WithDescription("Cancel a ticket by its ID")
+            .WithOpenApi();
     }
 }


### PR DESCRIPTION
## Summary
- add missing OpenAPI information to `TicketEndpoints`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840539ec5bc832a99fbb8e6b720c511