### PR TITLE
Fix city details endpoint auth/return type

### DIFF
--- a/src/TrackEasy.Api/Endpoints/CitiesEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/CitiesEndpoints.cs
@@ -41,9 +41,9 @@ public class CitiesEndpoints : IEndpoints
                 var city = await sender.Send(new FindCityQuery(id), cancellationToken);
                 return city is null ? Results.NotFound() : Results.Ok(city);
             })
-            .RequireAdminAccess()
+            .RequireAuthorization()
             .WithName("FindCity")
-            .Produces<CityDto>()
+            .Produces<CityDetailsDto>()
             .Produces(StatusCodes.Status404NotFound)
             .WithDescription("Find a city by ID.")
             .WithOpenApi();


### PR DESCRIPTION
## Summary
- update city find endpoint to require any authenticated user
- return `CityDetailsDto` from the find city endpoint

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840552405f8832aaf25356fd83b36b5