### PR TITLE
Add queries for connection change requests

### DIFF
--- a/src/TrackEasy.Api/Endpoints/ConnectionChangeRequestsEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/ConnectionChangeRequestsEndpoints.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using TrackEasy.Api.AuthorizationHandlers;
+using TrackEasy.Application.Connections.FindConnectionChangeRequest;
+using TrackEasy.Application.Connections.GetConnectionChangeRequests;
+using TrackEasy.Shared.Pagination.Abstractions;
+
+namespace TrackEasy.Api.Endpoints;
+
+public class ConnectionChangeRequestsEndpoints : IEndpoints
+{
+    public static void MapEndpoints(RouteGroupBuilder rootGroup)
+    {
+        var group = rootGroup.MapGroup("/connection-change-requests").WithTags("Connection Change Requests");
+
+        group.MapGet("/", async ([AsParameters] GetConnectionChangeRequestsQuery query, ISender sender, CancellationToken ct) =>
+                await sender.Send(query, ct))
+            .RequireAdminAccess()
+            .WithName("GetConnectionChangeRequests")
+            .WithSummary("Get paginated connection change requests")
+            .Produces<PaginatedResult<ConnectionChangeRequestDto>>()
+            .WithDescription("Get paginated list of connection change requests")
+            .WithOpenApi();
+
+        group.MapGet("/{id:guid}", async (Guid id, ISender sender, CancellationToken ct) =>
+        {
+            var result = await sender.Send(new FindConnectionChangeRequestQuery(id), ct);
+            return result is not null ? Results.Ok(result) : Results.NotFound();
+        })
+            .RequireAdminAccess()
+            .WithName("FindConnectionChangeRequest")
+            .WithSummary("Find connection change request by connection ID")
+            .Produces<ConnectionChangeRequestDetailsDto>()
+            .Produces(StatusCodes.Status404NotFound)
+            .WithDescription("Get full details of a connection change request")
+            .WithOpenApi();
+    }
+}

--- a/src/TrackEasy.Application/Connections/FindConnectionChangeRequest/ConnectionChangeRequestDetailsDto.cs
+++ b/src/TrackEasy.Application/Connections/FindConnectionChangeRequest/ConnectionChangeRequestDetailsDto.cs
@@ -1,0 +1,12 @@
+using TrackEasy.Application.Connections.Shared;
+using TrackEasy.Domain.Connections;
+
+namespace TrackEasy.Application.Connections.FindConnectionChangeRequest;
+
+public sealed record ConnectionChangeRequestDetailsDto(
+    Guid ConnectionId,
+    string Name,
+    string OperatorName,
+    ConnectionRequestType RequestType,
+    ScheduleDto? Schedule,
+    IEnumerable<ConnectionStationDto>? Stations);

--- a/src/TrackEasy.Application/Connections/FindConnectionChangeRequest/FindConnectionChangeRequestQuery.cs
+++ b/src/TrackEasy.Application/Connections/FindConnectionChangeRequest/FindConnectionChangeRequestQuery.cs
@@ -1,0 +1,6 @@
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Application.Connections.FindConnectionChangeRequest;
+
+public sealed record FindConnectionChangeRequestQuery(Guid ConnectionId)
+    : IQuery<ConnectionChangeRequestDetailsDto?>;

--- a/src/TrackEasy.Application/Connections/GetConnectionChangeRequests/ConnectionChangeRequestDto.cs
+++ b/src/TrackEasy.Application/Connections/GetConnectionChangeRequests/ConnectionChangeRequestDto.cs
@@ -1,0 +1,11 @@
+namespace TrackEasy.Application.Connections.GetConnectionChangeRequests;
+
+using TrackEasy.Domain.Connections;
+
+public sealed record ConnectionChangeRequestDto(
+    Guid ConnectionId,
+    string Name,
+    string OperatorName,
+    string StartStation,
+    string EndStation,
+    ConnectionRequestType RequestType);

--- a/src/TrackEasy.Application/Connections/GetConnectionChangeRequests/GetConnectionChangeRequestsQuery.cs
+++ b/src/TrackEasy.Application/Connections/GetConnectionChangeRequests/GetConnectionChangeRequestsQuery.cs
@@ -1,0 +1,7 @@
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Pagination.Abstractions;
+
+namespace TrackEasy.Application.Connections.GetConnectionChangeRequests;
+
+public sealed record GetConnectionChangeRequestsQuery(int PageNumber, int PageSize)
+    : IQuery<PaginatedResult<ConnectionChangeRequestDto>>;

--- a/src/TrackEasy.Infrastructure/Queries/ConnectionChangeRequests/FindConnectionChangeRequestQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/ConnectionChangeRequests/FindConnectionChangeRequestQueryHandler.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using TrackEasy.Application.Connections.FindConnectionChangeRequest;
+using TrackEasy.Application.Connections.Shared;
+using TrackEasy.Infrastructure.Database;
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Infrastructure.Queries.ConnectionChangeRequests;
+
+internal sealed class FindConnectionChangeRequestQueryHandler(TrackEasyDbContext dbContext)
+    : IQueryHandler<FindConnectionChangeRequestQuery, ConnectionChangeRequestDetailsDto?>
+{
+    public async Task<ConnectionChangeRequestDetailsDto?> Handle(FindConnectionChangeRequestQuery request, CancellationToken cancellationToken)
+    {
+        return await dbContext.Connections
+            .AsNoTracking()
+            .Where(x => x.Id == request.ConnectionId && x.Request != null)
+            .Select(x => new ConnectionChangeRequestDetailsDto(
+                x.Id,
+                x.Name,
+                x.Operator.Name,
+                x.Request!.RequestType,
+                x.Request.Schedule != null ?
+                    new ScheduleDto(x.Request.Schedule.ValidFrom, x.Request.Schedule.ValidTo, x.Request.Schedule.DaysOfWeek.ToList()) : null,
+                x.Request.Stations != null ?
+                    x.Request.Stations.OrderBy(s => s.SequenceNumber)
+                        .Select(s => new ConnectionStationDto(s.StationId, s.ArrivalTime, s.DepartureTime, s.SequenceNumber)) : null
+            ))
+            .SingleOrDefaultAsync(cancellationToken);
+    }
+}

--- a/src/TrackEasy.Infrastructure/Queries/ConnectionChangeRequests/GetConnectionChangeRequestsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/ConnectionChangeRequests/GetConnectionChangeRequestsQueryHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using TrackEasy.Application.Connections.GetConnectionChangeRequests;
+using TrackEasy.Infrastructure.Database;
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Pagination.Abstractions;
+using TrackEasy.Shared.Pagination.Infrastructure;
+
+namespace TrackEasy.Infrastructure.Queries.ConnectionChangeRequests;
+
+internal sealed class GetConnectionChangeRequestsQueryHandler(TrackEasyDbContext dbContext)
+    : IQueryHandler<GetConnectionChangeRequestsQuery, PaginatedResult<ConnectionChangeRequestDto>>
+{
+    public async Task<PaginatedResult<ConnectionChangeRequestDto>> Handle(GetConnectionChangeRequestsQuery request, CancellationToken cancellationToken)
+    {
+        var query = dbContext.Connections
+            .AsNoTracking()
+            .Where(x => x.Request != null)
+            .Select(x => new ConnectionChangeRequestDto(
+                x.Id,
+                x.Name,
+                x.Operator.Name,
+                x.Stations.OrderBy(s => s.SequenceNumber).First().Station.Name,
+                x.Stations.OrderBy(s => s.SequenceNumber).Last().Station.Name,
+                x.Request!.RequestType
+            ));
+
+        return await query.PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs and queries to fetch connection change requests
- implement EF query handlers for listing and retrieving request details
- add admin endpoints for listing and viewing connection change requests

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847ad51da18832ab7cff14122283e1c