### PR TITLE
Add refund request endpoints

### DIFF
--- a/src/TrackEasy.Application/RefundRequests/FindRefundRequest/FindRefundRequestQuery.cs
+++ b/src/TrackEasy.Application/RefundRequests/FindRefundRequest/FindRefundRequestQuery.cs
@@ -1,0 +1,5 @@
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Application.RefundRequests.FindRefundRequest;
+
+public sealed record FindRefundRequestQuery(Guid Id) : IQuery<RefundRequestDetailsDto?>;

--- a/src/TrackEasy.Application/RefundRequests/FindRefundRequest/RefundRequestDetailsDto.cs
+++ b/src/TrackEasy.Application/RefundRequests/FindRefundRequest/RefundRequestDetailsDto.cs
@@ -1,0 +1,22 @@
+using TrackEasy.Application.Tickets.FindTicket;
+
+namespace TrackEasy.Application.RefundRequests.FindRefundRequest;
+
+public sealed record RefundRequestDetailsDto(
+    Guid Id,
+    int TicketNumber,
+    IEnumerable<PersonDetailsDto> People,
+    IEnumerable<int>? SeatNumbers,
+    DateOnly ConnectionDate,
+    IEnumerable<TicketConnectionStationDto> Stations,
+    string OperatorCode,
+    string OperatorName,
+    string TrainName,
+    Guid? QrCodeId,
+    string Status,
+    string Reason,
+    DateTime CreatedAt)
+{
+    public TimeOnly DepartureTime => Stations.Single(x => x.SequenceNumber == 1).DepartureTime!.Value;
+    public TimeOnly ArrivalTime => Stations.MaxBy(x => x.SequenceNumber)!.ArrivalTime!.Value;
+}

--- a/src/TrackEasy.Application/RefundRequests/GetRefundRequests/GetRefundRequestsQuery.cs
+++ b/src/TrackEasy.Application/RefundRequests/GetRefundRequests/GetRefundRequestsQuery.cs
@@ -1,0 +1,7 @@
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Pagination.Abstractions;
+
+namespace TrackEasy.Application.RefundRequests.GetRefundRequests;
+
+public sealed record GetRefundRequestsQuery(Guid OperatorId, int PageNumber, int PageSize)
+    : IQuery<PaginatedResult<RefundRequestDto>>;

--- a/src/TrackEasy.Application/RefundRequests/GetRefundRequests/RefundRequestDto.cs
+++ b/src/TrackEasy.Application/RefundRequests/GetRefundRequests/RefundRequestDto.cs
@@ -1,0 +1,10 @@
+namespace TrackEasy.Application.RefundRequests.GetRefundRequests;
+
+public sealed record RefundRequestDto(
+    Guid Id,
+    Guid TicketId,
+    int TicketNumber,
+    string EmailAddress,
+    DateOnly ConnectionDate,
+    string Reason,
+    DateTime CreatedAt);

--- a/src/TrackEasy.Infrastructure/Queries/RefundRequests/FindRefundRequestQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/RefundRequests/FindRefundRequestQueryHandler.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using TrackEasy.Application.RefundRequests.FindRefundRequest;
+using TrackEasy.Application.Tickets.FindTicket;
+using TrackEasy.Infrastructure.Database;
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Infrastructure.Queries.RefundRequests;
+
+internal sealed class FindRefundRequestQueryHandler(TrackEasyDbContext dbContext)
+    : IQueryHandler<FindRefundRequestQuery, RefundRequestDetailsDto?>
+{
+    public async Task<RefundRequestDetailsDto?> Handle(FindRefundRequestQuery request, CancellationToken cancellationToken)
+    {
+        return await dbContext.RefundRequests
+            .AsNoTracking()
+            .Where(x => x.Id == request.Id)
+            .Select(x => new RefundRequestDetailsDto(
+                x.Id,
+                x.Ticket.TicketNumber,
+                x.Ticket.Passengers.Select(p => new PersonDetailsDto(
+                    p.FirstName,
+                    p.LastName,
+                    p.DateOfBirth,
+                    p.Discount
+                )),
+                x.Ticket.SeatNumbers,
+                x.Ticket.ConnectionDate,
+                x.Ticket.Stations.Select(s => new TicketConnectionStationDto(
+                    s.Name,
+                    s.ArrivalTime,
+                    s.DepartureTime,
+                    s.SequenceNumber
+                )),
+                x.Ticket.OperatorCode,
+                x.Ticket.OperatorName,
+                x.Ticket.TrainName,
+                x.Ticket.QrCodeId,
+                x.Ticket.TicketStatus.ToString(),
+                x.Reason,
+                x.CreatedAt
+            ))
+            .SingleOrDefaultAsync(cancellationToken);
+    }
+}

--- a/src/TrackEasy.Infrastructure/Queries/RefundRequests/GetRefundRequestsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/RefundRequests/GetRefundRequestsQueryHandler.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using TrackEasy.Application.RefundRequests.GetRefundRequests;
+using TrackEasy.Infrastructure.Database;
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Pagination.Abstractions;
+using TrackEasy.Shared.Pagination.Infrastructure;
+
+namespace TrackEasy.Infrastructure.Queries.RefundRequests;
+
+internal sealed class GetRefundRequestsQueryHandler(TrackEasyDbContext dbContext)
+    : IQueryHandler<GetRefundRequestsQuery, PaginatedResult<RefundRequestDto>>
+{
+    public async Task<PaginatedResult<RefundRequestDto>> Handle(GetRefundRequestsQuery request, CancellationToken cancellationToken)
+    {
+        return await dbContext.RefundRequests
+            .AsNoTracking()
+            .Where(x => x.Ticket.OperatorId == request.OperatorId)
+            .OrderByDescending(x => x.CreatedAt)
+            .Select(x => new RefundRequestDto(
+                x.Id,
+                x.TicketId,
+                x.Ticket.TicketNumber,
+                x.Ticket.EmailAddress,
+                x.Ticket.ConnectionDate,
+                x.Reason,
+                x.CreatedAt
+            ))
+            .PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- expose refund request queries under operators endpoints

## Testing
- `dotnet build TrackEasy.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847adbcf8e8832a9d757542cbf0aad2