### PR TITLE
Add Google and Microsoft external login

### DIFF
--- a/src/TrackEasy.Api/appsettings.json
+++ b/src/TrackEasy.Api/appsettings.json
@@ -14,5 +14,6 @@
     "Issuer": "TrackEasy",
     "Audience": "TrackEasyUsers",
     "ExpirationInMinutes": 30
-  }
+  },
+  
 }

--- a/src/TrackEasy.Application/Users/Codes.cs
+++ b/src/TrackEasy.Application/Users/Codes.cs
@@ -14,4 +14,6 @@ public static class Codes
     public const string PasswordResetFailed = "password_reset_failed";
     public const string InvalidToken = "invalid_token";
     public const string UserUpdateFailed = "user_update_failed";
+    public const string ExternalLoginFailed = "external_login_failed";
+    public const string EmailNotProvided = "email_not_provided";
 }

--- a/src/TrackEasy.Application/Users/ExternalLogin/ExternalLoginCommand.cs
+++ b/src/TrackEasy.Application/Users/ExternalLogin/ExternalLoginCommand.cs
@@ -1,0 +1,5 @@
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Application.Users.ExternalLogin;
+
+public sealed record ExternalLoginCommand(string Provider, string FirstName, string LastName, DateOnly DateOfBirth) : ICommand<string>;

--- a/src/TrackEasy.Application/Users/ExternalLogin/ExternalLoginCommandHandler.cs
+++ b/src/TrackEasy.Application/Users/ExternalLogin/ExternalLoginCommandHandler.cs
@@ -1,0 +1,63 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using TrackEasy.Application.Security;
+using TrackEasy.Domain.Users;
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.Application.Users.ExternalLogin;
+
+internal sealed class ExternalLoginCommandHandler(
+    SignInManager<User> signInManager,
+    UserManager<User> userManager,
+    IJwtService jwtService,
+    TimeProvider timeProvider) : ICommandHandler<ExternalLoginCommand, string>
+{
+    public async Task<string> Handle(ExternalLoginCommand request, CancellationToken cancellationToken)
+    {
+        var info = await signInManager.GetExternalLoginInfoAsync();
+        if (info is null || !string.Equals(info.LoginProvider, request.Provider, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new TrackEasyException(Codes.ExternalLoginFailed, "External login information not found.");
+        }
+
+        var email = info.Principal.FindFirstValue(ClaimTypes.Email);
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            throw new TrackEasyException(Codes.EmailNotProvided, "Email not provided by external provider.");
+        }
+
+        var user = await userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
+        if (user is null)
+        {
+            user = User.CreatePassenger(request.FirstName, request.LastName, email, request.DateOfBirth, timeProvider);
+            var createResult = await userManager.CreateAsync(user);
+            if (!createResult.Succeeded)
+            {
+                var errors = createResult.Errors.Select(e => e.Description).ToList();
+                throw new TrackEasyException(Codes.UserCreationFailed, $"User creation failed: {string.Join(", ", errors)}");
+            }
+
+            var roleResult = await userManager.AddToRoleAsync(user, Roles.Passenger);
+            if (!roleResult.Succeeded)
+            {
+                var errors = roleResult.Errors.Select(e => e.Description).ToList();
+                throw new TrackEasyException(Codes.UserRoleAdditionFailed, $"User role addition failed: {string.Join(", ", errors)}");
+            }
+
+            var loginResult = await userManager.AddLoginAsync(user, info);
+            if (!loginResult.Succeeded)
+            {
+                var errors = loginResult.Errors.Select(e => e.Description).ToList();
+                throw new TrackEasyException(Codes.ExternalLoginFailed, $"External login addition failed: {string.Join(", ", errors)}");
+            }
+        }
+
+        await signInManager.SignInAsync(user, isPersistent: false);
+        await signInManager.UpdateExternalAuthenticationTokensAsync(info);
+
+        var roles = await userManager.GetRolesAsync(user);
+        return jwtService.GenerateToken(user.Id, user.Email!, roles.First(), true, null);
+    }
+}
+

--- a/src/TrackEasy.Infrastructure/Extensions.cs
+++ b/src/TrackEasy.Infrastructure/Extensions.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Identity;
@@ -50,9 +51,15 @@ public static class Extensions
             })
             .AddRoles<IdentityRole<Guid>>()
             .AddEntityFrameworkStores<TrackEasyDbContext>()
-            .AddDefaultTokenProviders();
+            .AddDefaultTokenProviders()
+            .AddSignInManager();
         
-        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        })
+        .AddCookie(IdentityConstants.ExternalScheme)
         .AddJwtBearer(options =>
         {
             var key = Encoding.ASCII.GetBytes(configuration["Jwt:Key"]!);
@@ -66,6 +73,18 @@ public static class Extensions
                 ValidAudience = configuration["Jwt:Audience"],
                 IssuerSigningKey = new SymmetricSecurityKey(key)
             };
+        })
+        .AddGoogle(options =>
+        {
+            options.ClientId = configuration["google-clientid"]!;
+            options.ClientSecret = configuration["google-clientsecret"]!;
+            options.SignInScheme = IdentityConstants.ExternalScheme;
+        })
+        .AddMicrosoftAccount(options =>
+        {
+            options.ClientId = configuration["microsoft-clientid"]!;
+            options.ClientSecret = configuration["microsoft-clientsecret"]!;
+            options.SignInScheme = IdentityConstants.ExternalScheme;
         });
         
         services.AddHttpContextAccessor();

--- a/src/TrackEasy.Infrastructure/TrackEasy.Infrastructure.csproj
+++ b/src/TrackEasy.Infrastructure/TrackEasy.Infrastructure.csproj
@@ -15,8 +15,11 @@
       <ProjectReference Include="..\TrackEasy.Shared.Pagination.Infrastructure\TrackEasy.Shared.Pagination.Infrastructure.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.3" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="9.0.3" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="9.0.3" />
       <PackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="9.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">


### PR DESCRIPTION
## Summary
- add authentication packages for external providers
- configure Google and Microsoft authentication schemes
- allow initiating and handling external login for Passenger role
- store provider secrets in configuration
- remove provider placeholders from `appsettings.json` and read from `google-clientid`/`google-clientsecret` and `microsoft-clientid`/`microsoft-clientsecret` keys

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458726f84c832a9be980d307c9c1b3