### PR TITLE
Add notifications query and endpoint

### DIFF
--- a/src/TrackEasy.Api/Endpoints/NotificationsEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/NotificationsEndpoints.cs
@@ -1,0 +1,22 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using TrackEasy.Application.Notifications.GetNotifications;
+using TrackEasy.Shared.Pagination.Abstractions;
+
+namespace TrackEasy.Api.Endpoints;
+
+public class NotificationsEndpoints : IEndpoints
+{
+    public static void MapEndpoints(RouteGroupBuilder rootGroup)
+    {
+        var group = rootGroup.MapGroup("/notifications").WithTags("Notifications");
+
+        group.MapGet("/", async ([AsParameters] GetNotificationsQuery query, ISender sender, CancellationToken ct) =>
+                await sender.Send(query, ct))
+            .RequireAuthorization()
+            .WithName("GetNotifications")
+            .Produces<PaginatedResult<NotificationDto>>()
+            .WithDescription("Get paginated notifications for the current user.")
+            .WithOpenApi();
+    }
+}

--- a/src/TrackEasy.Application/Notifications/GetNotifications/GetNotificationsQuery.cs
+++ b/src/TrackEasy.Application/Notifications/GetNotifications/GetNotificationsQuery.cs
@@ -1,0 +1,7 @@
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Pagination.Abstractions;
+
+namespace TrackEasy.Application.Notifications.GetNotifications;
+
+public sealed record GetNotificationsQuery(int PageNumber, int PageSize)
+    : IQuery<PaginatedResult<NotificationDto>>;

--- a/src/TrackEasy.Application/Notifications/GetNotifications/NotificationDto.cs
+++ b/src/TrackEasy.Application/Notifications/GetNotifications/NotificationDto.cs
@@ -1,0 +1,11 @@
+namespace TrackEasy.Application.Notifications.GetNotifications;
+
+using TrackEasy.Domain.Notifications;
+
+public sealed record NotificationDto(
+    Guid Id,
+    string Title,
+    string Message,
+    NotificationType Type,
+    Guid ObjectId,
+    DateTime CreatedAt);

--- a/src/TrackEasy.Infrastructure/Queries/Notifications/GetNotificationsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Notifications/GetNotificationsQueryHandler.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using TrackEasy.Application.Notifications.GetNotifications;
+using TrackEasy.Application.Security;
+using TrackEasy.Domain.Notifications;
+using TrackEasy.Infrastructure.Database;
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Pagination.Abstractions;
+using TrackEasy.Shared.Pagination.Infrastructure;
+
+namespace TrackEasy.Infrastructure.Queries.Notifications;
+
+internal sealed class GetNotificationsQueryHandler(
+    TrackEasyDbContext dbContext,
+    IUserContext userContext)
+    : IQueryHandler<GetNotificationsQuery, PaginatedResult<NotificationDto>>
+{
+    public async Task<PaginatedResult<NotificationDto>> Handle(
+        GetNotificationsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var userId = userContext.UserId ?? throw new InvalidOperationException("User is not authenticated.");
+
+        return await dbContext.Notifications
+            .AsNoTracking()
+            .Where(n => n.UserId == userId)
+            .OrderByDescending(n => n.CreatedAt)
+            .Select(n => new NotificationDto(
+                n.Id,
+                n.Title,
+                n.Message,
+                n.Type,
+                n.ObjectId,
+                n.CreatedAt))
+            .PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add query and DTO to fetch paginated notifications for current user
- implement handler returning notifications from DB
- expose `/notifications` endpoint

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d7a9ad00832a95d78ac49f9dca24