### PR TITLE
Add notifications count endpoint

### DIFF
--- a/src/TrackEasy.Api/Endpoints/NotificationsEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/NotificationsEndpoints.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using TrackEasy.Application.Notifications.GetNotifications;
+using TrackEasy.Application.Notifications.GetNotificationsCount;
 using TrackEasy.Shared.Pagination.Abstractions;
 
 namespace TrackEasy.Api.Endpoints;
@@ -17,6 +18,14 @@ public class NotificationsEndpoints : IEndpoints
             .WithName("GetNotifications")
             .Produces<PaginatedResult<NotificationDto>>()
             .WithDescription("Get paginated notifications for the current user.")
+            .WithOpenApi();
+
+        group.MapGet("/count", async (ISender sender, CancellationToken ct) =>
+            await sender.Send(new GetNotificationsCountQuery(), ct))
+            .RequireAuthorization()
+            .WithName("GetNotificationsCount")
+            .Produces<int>()
+            .WithDescription("Get notifications count for the current user.")
             .WithOpenApi();
     }
 }

--- a/src/TrackEasy.Application/Notifications/GetNotificationsCount/GetNotificationsCountQuery.cs
+++ b/src/TrackEasy.Application/Notifications/GetNotificationsCount/GetNotificationsCountQuery.cs
@@ -1,0 +1,5 @@
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Application.Notifications.GetNotificationsCount;
+
+public sealed record GetNotificationsCountQuery : IQuery<int>;

--- a/src/TrackEasy.Infrastructure/Queries/Notifications/GetNotificationsCountQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Notifications/GetNotificationsCountQueryHandler.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using TrackEasy.Application.Notifications.GetNotificationsCount;
+using TrackEasy.Application.Security;
+using TrackEasy.Infrastructure.Database;
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Infrastructure.Queries.Notifications;
+
+internal sealed class GetNotificationsCountQueryHandler(
+    TrackEasyDbContext dbContext,
+    IUserContext userContext)
+    : IQueryHandler<GetNotificationsCountQuery, int>
+{
+    public async Task<int> Handle(GetNotificationsCountQuery request, CancellationToken cancellationToken)
+    {
+        var userId = userContext.UserId ?? throw new InvalidOperationException("User is not authenticated.");
+
+        return await dbContext.Notifications
+            .AsNoTracking()
+            .CountAsync(n => n.UserId == userId, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add query to fetch notifications count
- implement handler to return count for current user
- expose new `/notifications/count` endpoint

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e351f410832a8980d1853858540c