### PR TITLE
Add notification deletion endpoint

### DIFF
--- a/src/TrackEasy.Api/Endpoints/NotificationsEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/NotificationsEndpoints.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using TrackEasy.Application.Notifications.GetNotifications;
 using TrackEasy.Application.Notifications.GetNotificationsCount;
+using TrackEasy.Application.Notifications.DeleteNotification;
 using TrackEasy.Shared.Pagination.Abstractions;
 
 namespace TrackEasy.Api.Endpoints;
@@ -26,6 +27,19 @@ public class NotificationsEndpoints : IEndpoints
             .WithName("GetNotificationsCount")
             .Produces<int>()
             .WithDescription("Get notifications count for the current user.")
+            .WithOpenApi();
+
+        group.MapDelete("/{id:guid}", async (Guid id, ISender sender, CancellationToken ct) =>
+        {
+            var command = new DeleteNotificationCommand(id);
+            await sender.Send(command, ct);
+            return Results.NoContent();
+        })
+            .RequireAuthorization()
+            .WithName("DeleteNotification")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .WithDescription("Mark a notification as read and remove it.")
             .WithOpenApi();
     }
 }

--- a/src/TrackEasy.Application/Connections/ConnectionRequestApproved/ConnectionRequestApprovedEventHandler.cs
+++ b/src/TrackEasy.Application/Connections/ConnectionRequestApproved/ConnectionRequestApprovedEventHandler.cs
@@ -6,7 +6,11 @@ using TrackEasy.Shared.Application.Abstractions;
 
 namespace TrackEasy.Application.Connections.ConnectionRequestApproved;
 
-internal sealed class ConnectionRequestApprovedEventHandler(IManagerRepository managerRepository, INotificationService notificationService, TimeProvider timeProvider)
+internal sealed class ConnectionRequestApprovedEventHandler(
+    IManagerRepository managerRepository,
+    INotificationRepository notificationRepository,
+    INotificationService notificationService,
+    TimeProvider timeProvider)
     : IDomainEventHandler<ConnectionRequestApprovedEvent>
 {
     public async Task Handle(ConnectionRequestApprovedEvent notification, CancellationToken cancellationToken)
@@ -24,11 +28,14 @@ internal sealed class ConnectionRequestApprovedEventHandler(IManagerRepository m
                  type: NotificationType.CONNECTION_REQUEST,
                  timeProvider: timeProvider
              );
-             
+
+             notificationRepository.Add(requestNotification);
+
              notificationTasks.Add(notificationService.SendNotificationAsync(requestNotification));
          }
-         
+
          await Task.WhenAll(notificationTasks);
+         await notificationRepository.SaveChangesAsync(cancellationToken);
     }
 
     private static string GenerateMessage(ConnectionRequestType type, string name)

--- a/src/TrackEasy.Application/Connections/ConnectionRequestCreated/ConnectionRequestCreatedEventHandler.cs
+++ b/src/TrackEasy.Application/Connections/ConnectionRequestCreated/ConnectionRequestCreatedEventHandler.cs
@@ -7,7 +7,11 @@ using TrackEasy.Shared.Application.Abstractions;
 
 namespace TrackEasy.Application.Connections.ConnectionRequestCreated;
 
-internal sealed class ConnectionRequestCreatedEventHandler(INotificationService notificationService, UserManager<User> userManager, TimeProvider timeProvider)
+internal sealed class ConnectionRequestCreatedEventHandler(
+    INotificationRepository notificationRepository,
+    INotificationService notificationService,
+    UserManager<User> userManager,
+    TimeProvider timeProvider)
     : IDomainEventHandler<ConnectionRequestCreatedEvent>
 {
     public async Task Handle(ConnectionRequestCreatedEvent notification, CancellationToken cancellationToken)
@@ -26,10 +30,13 @@ internal sealed class ConnectionRequestCreatedEventHandler(INotificationService 
                 type: NotificationType.CONNECTION_REQUEST,
                 timeProvider: timeProvider
             );
-            
+
+            notificationRepository.Add(requestNotification);
+
             notificationTasks.Add(notificationService.SendNotificationAsync(requestNotification));
         }
-        
+
         await Task.WhenAll(notificationTasks);
+        await notificationRepository.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/TrackEasy.Application/Notifications/DeleteNotification/DeleteNotificationCommand.cs
+++ b/src/TrackEasy.Application/Notifications/DeleteNotification/DeleteNotificationCommand.cs
@@ -1,0 +1,5 @@
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Application.Notifications.DeleteNotification;
+
+public sealed record DeleteNotificationCommand(Guid Id) : ICommand;

--- a/src/TrackEasy.Application/Notifications/DeleteNotification/DeleteNotificationCommandHandler.cs
+++ b/src/TrackEasy.Application/Notifications/DeleteNotification/DeleteNotificationCommandHandler.cs
@@ -1,0 +1,21 @@
+using TrackEasy.Domain.Notifications;
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.Application.Notifications.DeleteNotification;
+
+internal sealed class DeleteNotificationCommandHandler(INotificationRepository notificationRepository) : ICommandHandler<DeleteNotificationCommand>
+{
+    public async Task Handle(DeleteNotificationCommand request, CancellationToken cancellationToken)
+    {
+        var notification = await notificationRepository.FindByIdAsync(request.Id, cancellationToken);
+
+        if (notification is null)
+        {
+            throw new TrackEasyException(SharedCodes.EntityNotFound, $"Notification with id {request.Id} was not found.");
+        }
+
+        notificationRepository.Delete(notification);
+        await notificationRepository.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/TrackEasy.Application/RefundRequests/RefundRequestCreated/RefundRequestCreatedEventHandler.cs
+++ b/src/TrackEasy.Application/RefundRequests/RefundRequestCreated/RefundRequestCreatedEventHandler.cs
@@ -6,7 +6,11 @@ using TrackEasy.Shared.Application.Abstractions;
 
 namespace TrackEasy.Application.RefundRequests.RefundRequestCreated;
 
-internal sealed class RefundRequestCreatedEventHandler(IManagerRepository managerRepository, INotificationService notificationService, TimeProvider timeProvider) 
+internal sealed class RefundRequestCreatedEventHandler(
+    IManagerRepository managerRepository,
+    INotificationRepository notificationRepository,
+    INotificationService notificationService,
+    TimeProvider timeProvider)
     : IDomainEventHandler<RefundRequestCreatedEvent>
 {
     public async Task Handle(RefundRequestCreatedEvent notification, CancellationToken cancellationToken)
@@ -24,10 +28,13 @@ internal sealed class RefundRequestCreatedEventHandler(IManagerRepository manage
                 type: NotificationType.REFUND_REQUEST,
                 timeProvider: timeProvider
             );
-            
+
+            notificationRepository.Add(requestNotification);
+
             notificationTasks.Add(notificationService.SendNotificationAsync(requestNotification));
         }
-        
+
         await Task.WhenAll(notificationTasks);
+        await notificationRepository.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/TrackEasy.Domain/Notifications/INotificationRepository.cs
+++ b/src/TrackEasy.Domain/Notifications/INotificationRepository.cs
@@ -1,0 +1,10 @@
+using TrackEasy.Shared.Domain.Abstractions;
+
+namespace TrackEasy.Domain.Notifications;
+
+public interface INotificationRepository : IBaseRepository
+{
+    Task<Notification?> FindByIdAsync(Guid id, CancellationToken cancellationToken);
+    void Add(Notification notification);
+    void Delete(Notification notification);
+}

--- a/src/TrackEasy.Infrastructure/Database/Repositories/NotificationRepository.cs
+++ b/src/TrackEasy.Infrastructure/Database/Repositories/NotificationRepository.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using TrackEasy.Domain.Notifications;
+
+namespace TrackEasy.Infrastructure.Database.Repositories;
+
+internal sealed class NotificationRepository(TrackEasyDbContext dbContext) : BaseRepository(dbContext), INotificationRepository
+{
+    private readonly TrackEasyDbContext _dbContext = dbContext;
+
+    public async Task<Notification?> FindByIdAsync(Guid id, CancellationToken cancellationToken)
+        => await _dbContext.Notifications.FirstOrDefaultAsync(n => n.Id == id, cancellationToken);
+
+    public void Add(Notification notification)
+    {
+        _dbContext.Notifications.Add(notification);
+    }
+
+    public void Delete(Notification notification)
+    {
+        _dbContext.Notifications.Remove(notification);
+    }
+}


### PR DESCRIPTION
## Summary
- add command and handler to delete a notification
- implement notification repository
- expose delete endpoint `/notifications/{id}` to remove a notification
- persist created notifications in event handlers

## Testing
- `dotnet test --no-build -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a69290d84832a9aad893ce7ea9bd5