### PR TITLE
Add ticket price calculation endpoint

### DIFF
--- a/src/TrackEasy.Api/Endpoints/TicketEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/TicketEndpoints.cs
@@ -9,6 +9,8 @@ using TrackEasy.Application.Tickets.GetTicketCities;
 using TrackEasy.Application.Tickets.GetTickets;
 using TrackEasy.Application.Tickets.PayTicketByCard;
 using TrackEasy.Application.Tickets.PayTicketByCash;
+using TrackEasy.Application.Tickets.CalculateTicketPrice;
+using TrackEasy.Application.Shared;
 using TrackEasy.Shared.Pagination.Abstractions;
 
 namespace TrackEasy.Api.Endpoints;
@@ -25,6 +27,14 @@ public class TicketEndpoints : IEndpoints
             .Produces<IReadOnlyCollection<Guid>>()
             .Produces(StatusCodes.Status400BadRequest)
             .WithDescription("Purchase tickets for specified connections")
+            .WithOpenApi();
+
+        group.MapPost("/price", async (CalculateTicketPriceQuery query, ISender sender, CancellationToken ct) =>
+            Results.Ok(await sender.Send(query, ct)))
+            .WithName("CalculateTicketPrice")
+            .Produces<MoneyDto>()
+            .Produces(StatusCodes.Status400BadRequest)
+            .WithDescription("Calculate price for specified connections")
             .WithOpenApi();
         
         group.MapGet("/{userId:guid}", async (Guid userId, int pageNumber, int pageSize, TicketType type, ISender sender, CancellationToken ct) =>

--- a/src/TrackEasy.Application/Tickets/CalculateTicketPrice/CalculateTicketPriceQuery.cs
+++ b/src/TrackEasy.Application/Tickets/CalculateTicketPrice/CalculateTicketPriceQuery.cs
@@ -1,0 +1,12 @@
+using TrackEasy.Application.Tickets.BuyTicket;
+using TrackEasy.Application.Shared;
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Application.Tickets.CalculateTicketPrice;
+
+public sealed record CalculateTicketPriceQuery(
+    IEnumerable<PersonDto> Passengers,
+    Guid? DiscountCodeId,
+    IEnumerable<TicketConnectionDto> Connections
+) : IQuery<MoneyDto>;
+

--- a/src/TrackEasy.Infrastructure/Queries/Tickets/CalculateTicketPriceQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Tickets/CalculateTicketPriceQueryHandler.cs
@@ -1,0 +1,104 @@
+using TrackEasy.Application.Services;
+using TrackEasy.Application.Tickets.BuyTicket;
+using TrackEasy.Application.Tickets.CalculateTicketPrice;
+using TrackEasy.Application.Shared;
+using TrackEasy.Domain.Connections;
+using TrackEasy.Domain.DiscountCodes;
+using TrackEasy.Domain.Discounts;
+using TrackEasy.Domain.Shared;
+using TrackEasy.Domain.Stations;
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.Infrastructure.Queries.Tickets;
+
+internal sealed class CalculateTicketPriceQueryHandler(
+    IConnectionRepository connectionRepository,
+    IStationRepository stationRepository,
+    IDiscountCodeRepository discountCodeRepository,
+    IDiscountRepository discountRepository,
+    ITicketPriceService ticketPriceService,
+    TimeProvider timeProvider)
+    : IQueryHandler<CalculateTicketPriceQuery, MoneyDto>
+{
+    public async Task<MoneyDto> Handle(CalculateTicketPriceQuery request, CancellationToken cancellationToken)
+    {
+        if (request.Connections is null || !request.Connections.Any())
+            throw new TrackEasyException(SharedCodes.InvalidInput, "At least one connection is required.");
+
+        var discountCode = await ValidateDiscountCodeAsync(request.DiscountCodeId, discountCodeRepository, timeProvider, cancellationToken);
+
+        Money? totalPrice = null;
+
+        foreach (var dto in request.Connections)
+        {
+            var connection = await connectionRepository.FindByIdAsync(dto.Id, cancellationToken)
+                             ?? throw new TrackEasyException(SharedCodes.EntityNotFound, $"Connection {dto.Id} was not found.");
+
+            if (!connection.IsConnectionRunning(dto.ConnectionDate))
+                throw new TrackEasyException(SharedCodes.InvalidInput, $"Connection {dto.Id} does not run on {dto.ConnectionDate:yyyy-MM-dd}.");
+
+            var (start, end) = await LoadAndValidateStationsAsync(dto.StartStationId, dto.EndStationId, connection, stationRepository, cancellationToken);
+
+            var pricing = await ticketPriceService.CalculateAsync(
+                connection,
+                request.Passengers,
+                start.Id,
+                end.Id,
+                discountCode,
+                dto.ConnectionDate,
+                cancellationToken);
+
+            if (totalPrice is null)
+            {
+                totalPrice = pricing.Price;
+            }
+            else
+            {
+                if (totalPrice.Currency != pricing.Price.Currency)
+                    throw new TrackEasyException(SharedCodes.InvalidInput, "Connections use different currencies.");
+                totalPrice += pricing.Price;
+            }
+        }
+
+        totalPrice ??= new Money(0, Currency.PLN);
+
+        return new MoneyDto(totalPrice.Amount, totalPrice.Currency);
+    }
+
+    private static async Task<DiscountCode?> ValidateDiscountCodeAsync(
+        Guid? codeId,
+        IDiscountCodeRepository repo,
+        TimeProvider tp,
+        CancellationToken ct)
+    {
+        if (codeId is null) return null;
+
+        var code = await repo.GetByIdAsync(codeId.Value, ct)
+                   ?? throw new TrackEasyException(SharedCodes.EntityNotFound, $"Discount code {codeId} was not found.");
+
+        if (!code.IsActive(tp))
+            throw new TrackEasyException(SharedCodes.InvalidInput, "The provided discount code is not active.");
+
+        return code;
+    }
+
+    private static async Task<(Station start, Station end)> LoadAndValidateStationsAsync(
+        Guid startId, Guid endId, Connection connection,
+        IStationRepository repo, CancellationToken ct)
+    {
+        var start = await repo.GetByIdAsync(startId, ct)
+                    ?? throw new TrackEasyException(SharedCodes.EntityNotFound, $"Start station {startId} not found.");
+        var end = await repo.GetByIdAsync(endId, ct)
+                    ?? throw new TrackEasyException(SharedCodes.EntityNotFound, $"End station {endId} not found.");
+
+        if (start.Id == end.Id)
+            throw new TrackEasyException(SharedCodes.InvalidInput, "Start and end stations cannot be the same.");
+
+        if (connection.Stations.All(s => s.StationId != start.Id) || connection.Stations.All(s => s.StationId != end.Id))
+            throw new TrackEasyException(SharedCodes.InvalidInput, "Start and end stations must belong to the connection.");
+
+        return (start, end);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `CalculateTicketPriceQuery` to calculate ticket price without purchase
- handle query in `CalculateTicketPriceQueryHandler`
- expose new `/tickets/price` endpoint

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684aa449fdf8832a8a0c3afb8f871119