### PR TITLE
Use Id-based domain events

### DIFF
--- a/src/TrackEasy.Application/Tickets/TicketCreatedForExternalUser/TicketCreatedForExternalUserEventHandler.cs
+++ b/src/TrackEasy.Application/Tickets/TicketCreatedForExternalUser/TicketCreatedForExternalUserEventHandler.cs
@@ -5,11 +5,17 @@ using TrackEasy.Shared.Application.Abstractions;
 
 namespace TrackEasy.Application.Tickets.TicketCreatedForExternalUser;
 
-internal sealed class TicketCreatedForExternalUserEventHandler(IEmailSender emailSender) : IDomainEventHandler<TicketCreatedForExternalUserEvent>
+internal sealed class TicketCreatedForExternalUserEventHandler(ITicketRepository ticketRepository, IEmailSender emailSender) : IDomainEventHandler<TicketCreatedForExternalUserEvent>
 {
     public async Task Handle(TicketCreatedForExternalUserEvent notification, CancellationToken cancellationToken)
     {
-        var model = new TicketNumberModel(notification.Ticket.TicketNumber);
-        await emailSender.SendTicketNumberEmailAsync(notification.Ticket.EmailAddress, model);
+        var ticket = await ticketRepository.FindByIdAsync(notification.TicketId, cancellationToken);
+        if (ticket is null)
+        {
+            return;
+        }
+
+        var model = new TicketNumberModel(ticket.TicketNumber);
+        await emailSender.SendTicketNumberEmailAsync(ticket.EmailAddress, model);
     }
 }

--- a/src/TrackEasy.Application/Tickets/TicketPayed/TicketPayedEventHandler.cs
+++ b/src/TrackEasy.Application/Tickets/TicketPayed/TicketPayedEventHandler.cs
@@ -24,11 +24,11 @@ internal sealed class TicketPayedEventHandler(
     
     public async Task Handle(TicketPayedEvent notification, CancellationToken cancellationToken)
     {
-        var ticket = await ticketRepository.FindByIdAsync(notification.Ticket.Id, cancellationToken);
+        var ticket = await ticketRepository.FindByIdAsync(notification.TicketId, cancellationToken);
         
         if (ticket is null)
         {
-            throw new TrackEasyException(SharedCodes.EntityNotFound, $"Ticket with ID {notification.Ticket.Id} was not found.");
+            throw new TrackEasyException(SharedCodes.EntityNotFound, $"Ticket with ID {notification.TicketId} was not found.");
         }
         
         var qrCode = GenerateQrCode(ticket.Id);

--- a/src/TrackEasy.Application/Users/UserCreated/UserCreatedEventHandler.cs
+++ b/src/TrackEasy.Application/Users/UserCreated/UserCreatedEventHandler.cs
@@ -11,10 +11,16 @@ internal sealed class UserCreatedEventHandler(UserManager<User> userManager, IEm
 {
     public async Task Handle(UserCreatedEvent notification, CancellationToken cancellationToken)
     {
-        var token = await userManager.GenerateEmailConfirmationTokenAsync(notification.User);
-        
+        var user = await userManager.FindByIdAsync(notification.UserId.ToString());
+        if (user is null)
+        {
+            return;
+        }
+
+        var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
+
         var url = configuration["frontend-url"]!;
-        var model = new ActivateEmailModel(notification.User.FirstName!, notification.User.LastName!, notification.User.Email!, token, url);
-        await emailSender.SendAccountConfirmationEmailAsync(notification.User.Email!, model);
+        var model = new ActivateEmailModel(user.FirstName!, user.LastName!, user.Email!, token, url);
+        await emailSender.SendAccountConfirmationEmailAsync(user.Email!, model);
     }
 }

--- a/src/TrackEasy.Domain/Tickets/Ticket.cs
+++ b/src/TrackEasy.Domain/Tickets/Ticket.cs
@@ -56,7 +56,7 @@ public sealed class Ticket : AggregateRoot
 
         if (passengerId is null)
         {
-            ticket.AddDomainEvent(new TicketCreatedForExternalUserEvent(ticket));
+            ticket.AddDomainEvent(new TicketCreatedForExternalUserEvent(ticket.Id));
         }
         
         new TicketValidator().ValidateAndThrow(ticket);
@@ -69,7 +69,7 @@ public sealed class Ticket : AggregateRoot
         PaidAt = timeProvider.GetUtcNow().DateTime;
         TransactionId = transactionId;
         new TicketValidator().ValidateAndThrow(this);
-        AddDomainEvent(new TicketPayedEvent(this));
+        AddDomainEvent(new TicketPayedEvent(Id));
     }
     
     public void Cancel(TimeProvider timeProvider)

--- a/src/TrackEasy.Domain/Tickets/TicketCreatedForExternalUserEvent.cs
+++ b/src/TrackEasy.Domain/Tickets/TicketCreatedForExternalUserEvent.cs
@@ -2,4 +2,4 @@ using TrackEasy.Shared.Domain.Abstractions;
 
 namespace TrackEasy.Domain.Tickets;
 
-public sealed record TicketCreatedForExternalUserEvent(Ticket Ticket) : IDomainEvent;
+public sealed record TicketCreatedForExternalUserEvent(Guid TicketId) : IDomainEvent;

--- a/src/TrackEasy.Domain/Tickets/TicketPayedEvent.cs
+++ b/src/TrackEasy.Domain/Tickets/TicketPayedEvent.cs
@@ -2,4 +2,4 @@ using TrackEasy.Shared.Domain.Abstractions;
 
 namespace TrackEasy.Domain.Tickets;
 
-public sealed record TicketPayedEvent(Ticket Ticket) : IDomainEvent;
+public sealed record TicketPayedEvent(Guid TicketId) : IDomainEvent;

--- a/src/TrackEasy.Domain/Users/User.cs
+++ b/src/TrackEasy.Domain/Users/User.cs
@@ -62,7 +62,7 @@ public sealed class User : IdentityUser<Guid>, IAggregateRoot
         new UserValidator(timeProvider).ValidateAndThrow(user);
         
         if (twoFactorEnabled)
-            user.AddDomainEvent(new UserCreatedEvent(user));
+            user.AddDomainEvent(new UserCreatedEvent(user.Id));
         
         return user;
     }

--- a/src/TrackEasy.Domain/Users/UserCreatedEvent.cs
+++ b/src/TrackEasy.Domain/Users/UserCreatedEvent.cs
@@ -2,4 +2,4 @@ using TrackEasy.Shared.Domain.Abstractions;
 
 namespace TrackEasy.Domain.Users;
 
-public sealed record UserCreatedEvent(User User) : IDomainEvent;
+public sealed record UserCreatedEvent(Guid UserId) : IDomainEvent;

--- a/src/TrackEasy.UnitTests/Tickets/TicketTests.cs
+++ b/src/TrackEasy.UnitTests/Tickets/TicketTests.cs
@@ -172,7 +172,7 @@ public class TicketTests
         ticket.TransactionId.ShouldBe(transactionId);
         ticket.DomainEvents.Count.ShouldBe(1);
         ticket.DomainEvents.First().ShouldBeOfType<TicketPayedEvent>();
-        ((TicketPayedEvent)ticket.DomainEvents.First()).Ticket.Id.ShouldBe(ticket.Id);
+        ((TicketPayedEvent)ticket.DomainEvents.First()).TicketId.ShouldBe(ticket.Id);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- use Guid identifiers instead of entity objects in domain event definitions
- adjust event handlers to load entities by id
- update ticket domain creation/pay methods
- update unit tests for new event shape

## Testing
- `dotnet format --no-restore` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaec81fe4832aa5b7169494864ce8