### PR TITLE
Add return URL for Stripe payments

### DIFF
--- a/src/TrackEasy.Application/Tickets/PayTicketByCard/PayTicketByCardCommandHandler.cs
+++ b/src/TrackEasy.Application/Tickets/PayTicketByCard/PayTicketByCardCommandHandler.cs
@@ -48,6 +48,7 @@ internal sealed class PayTicketByCardCommandHandler(
         {
             Amount = totalPrice.ToMinorUnits(),
             Currency = totalPrice.GetCurrencyCode(),
+            ReturnUrl = "https://example.com/payment-complete",
             Confirm = true,
             PaymentMethodData = new PaymentIntentPaymentMethodDataOptions
             {


### PR DESCRIPTION
## Summary
- specify ReturnUrl for PaymentIntent creation so Stripe can redirect after payment

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ab3d59080832aa1b15c7274ebbdf7