### PR TITLE
Fix external login scheme names

### DIFF
--- a/src/TrackEasy.Api/Endpoints/UserEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/UserEndpoints.cs
@@ -114,7 +114,15 @@ public class UserEndpoints : IEndpoints
             properties.Items["firstName"] = firstName;
             properties.Items["lastName"] = lastName;
             properties.Items["dob"] = dateOfBirth.ToString("O");
-            return Results.Challenge(properties, [provider]);
+
+            var scheme = provider.ToLowerInvariant() switch
+            {
+                "google" => "Google",
+                "microsoft" => "Microsoft",
+                _ => provider
+            };
+
+            return Results.Challenge(properties, [scheme]);
         })
             .AllowAnonymous()
             .WithName("ExternalLoginChallenge")


### PR DESCRIPTION
## Summary
- handle case-insensitive provider names when challenging external login schemes

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ac5edca50832ab846f4a1f84a493f