### PR TITLE
Fix Google sign-in redirect

### DIFF
--- a/src/TrackEasy.Infrastructure/Extensions.cs
+++ b/src/TrackEasy.Infrastructure/Extensions.cs
@@ -79,12 +79,16 @@ public static class Extensions
             options.ClientId = configuration["google-clientid"]!;
             options.ClientSecret = configuration["google-clientsecret"]!;
             options.SignInScheme = IdentityConstants.ExternalScheme;
+            // Use the same callback path as the endpoint handling the login
+            // callback to avoid redirect URI mismatches.
+            options.CallbackPath = "/users/external/google/callback";
         })
         .AddMicrosoftAccount(options =>
         {
             options.ClientId = configuration["microsoft-clientid"]!;
             options.ClientSecret = configuration["microsoft-clientsecret"]!;
             options.SignInScheme = IdentityConstants.ExternalScheme;
+            options.CallbackPath = "/users/external/microsoft/callback";
         });
         
         services.AddHttpContextAccessor();


### PR DESCRIPTION
## Summary
- ensure Google and Microsoft external login callbacks match the endpoint paths

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac91a5f04832ab2465bce2f78224a