### PR TITLE
Add arrival times query for tickets

### DIFF
--- a/src/TrackEasy.Api/Endpoints/TicketEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/TicketEndpoints.cs
@@ -6,6 +6,7 @@ using TrackEasy.Application.Tickets.FindCurrentTicketId;
 using TrackEasy.Application.Tickets.FindTicket;
 using TrackEasy.Application.Tickets.GetQrCode;
 using TrackEasy.Application.Tickets.GetTicketCities;
+using TrackEasy.Application.Tickets.GetTicketArrivalTimes;
 using TrackEasy.Application.Tickets.GetTickets;
 using TrackEasy.Application.Tickets.PayTicketByCard;
 using TrackEasy.Application.Tickets.PayTicketByCash;
@@ -60,6 +61,13 @@ public class TicketEndpoints : IEndpoints
             .WithName("GetTicketCities")
             .Produces<IEnumerable<TicketCityDto>>()
             .WithDescription("Get cities related to a ticket")
+            .WithOpenApi();
+
+        group.MapGet("/{id:guid}/arrivals", async (Guid id, ISender sender, CancellationToken ct) =>
+            Results.Ok(await sender.Send(new GetTicketArrivalTimesQuery(id), ct)))
+            .WithName("GetTicketArrivals")
+            .Produces<IEnumerable<TicketArrivalDto>>()
+            .WithDescription("Get arrival times with city names for a ticket")
             .WithOpenApi();
         
         group.MapGet("/qr-code/{qrCodeId:guid}", async (Guid qrCodeId, ISender sender, CancellationToken ct) =>

--- a/src/TrackEasy.Application/Tickets/GetTicketArrivalTimes/GetTicketArrivalTimesQuery.cs
+++ b/src/TrackEasy.Application/Tickets/GetTicketArrivalTimes/GetTicketArrivalTimesQuery.cs
@@ -1,0 +1,5 @@
+using TrackEasy.Shared.Application.Abstractions;
+
+namespace TrackEasy.Application.Tickets.GetTicketArrivalTimes;
+
+public sealed record GetTicketArrivalTimesQuery(Guid Id) : IQuery<IEnumerable<TicketArrivalDto>>;

--- a/src/TrackEasy.Application/Tickets/GetTicketArrivalTimes/TicketArrivalDto.cs
+++ b/src/TrackEasy.Application/Tickets/GetTicketArrivalTimes/TicketArrivalDto.cs
@@ -1,0 +1,3 @@
+namespace TrackEasy.Application.Tickets.GetTicketArrivalTimes;
+
+public sealed record TicketArrivalDto(string CityName, TimeOnly ArrivalTime);

--- a/src/TrackEasy.Infrastructure/Queries/Tickets/GetTicketArrivalTimesQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Tickets/GetTicketArrivalTimesQueryHandler.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using TrackEasy.Application.Tickets.GetTicketArrivalTimes;
+using TrackEasy.Infrastructure.Database;
+using TrackEasy.Shared.Application.Abstractions;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.Infrastructure.Queries.Tickets;
+
+internal sealed class GetTicketArrivalTimesQueryHandler(TrackEasyDbContext dbContext)
+    : IQueryHandler<GetTicketArrivalTimesQuery, IEnumerable<TicketArrivalDto>>
+{
+    public async Task<IEnumerable<TicketArrivalDto>> Handle(GetTicketArrivalTimesQuery request, CancellationToken cancellationToken)
+    {
+        var ticket = await dbContext.Tickets
+            .Where(x => x.Id == request.Id)
+            .Include(x => x.Stations)
+            .SingleOrDefaultAsync(cancellationToken);
+        if (ticket is null)
+        {
+            throw new TrackEasyException(SharedCodes.EntityNotFound, $"Ticket with ID {request.Id} was not found.");
+        }
+
+        var connection = await dbContext.Connections
+            .Where(x => x.Id == ticket.ConnectionId)
+            .Include(x => x.Stations)
+                .ThenInclude(cs => cs.Station)
+                    .ThenInclude(s => s.City)
+            .SingleOrDefaultAsync(cancellationToken);
+        if (connection is null)
+        {
+            throw new TrackEasyException(SharedCodes.EntityNotFound, $"Connection with ID {ticket.ConnectionId} was not found.");
+        }
+
+        return connection.Stations
+            .Where(cs => ticket.Stations.Any(ts => ts.SequenceNumber == cs.SequenceNumber && ts.ArrivalTime.HasValue))
+            .OrderBy(cs => cs.SequenceNumber)
+            .Select(cs => new TicketArrivalDto(
+                cs.Station.City.Name,
+                ticket.Stations.Single(ts => ts.SequenceNumber == cs.SequenceNumber).ArrivalTime!.Value))
+            .ToList();
+    }
+}


### PR DESCRIPTION
## Summary
- add new TicketArrivalTimes query to return city name with arrival time
- implement query handler
- expose new `/tickets/{id}/arrivals` API endpoint

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adbdca618832a88ad291aebc26b8f