### PR TITLE
Add consistent ordering in paginated and list queries

### DIFF
--- a/src/TrackEasy.Infrastructure/Queries/Cities/GetCitiesQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Cities/GetCitiesQueryHandler.cs
@@ -16,6 +16,7 @@ internal sealed class GetCitiesQueryHandler(TrackEasyDbContext dbContext)
         return await dbContext.Cities
             .AsNoTracking()
             .WithName(request.Name)
+            .OrderBy(c => c.Name)
             .Select(x => new CityDto(x.Id, x.Name, x.Country.GetEnumDescription()))
             .PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);
     }

--- a/src/TrackEasy.Infrastructure/Queries/ConnectionChangeRequests/GetConnectionChangeRequestsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/ConnectionChangeRequests/GetConnectionChangeRequestsQueryHandler.cs
@@ -15,6 +15,7 @@ internal sealed class GetConnectionChangeRequestsQueryHandler(TrackEasyDbContext
         var query = dbContext.Connections
             .AsNoTracking()
             .Where(x => x.Request != null)
+            .OrderBy(x => x.Name)
             .Select(x => new ConnectionChangeRequestDto(
                 x.Id,
                 x.Name,

--- a/src/TrackEasy.Infrastructure/Queries/Connections/GetConnectionsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Connections/GetConnectionsQueryHandler.cs
@@ -12,6 +12,7 @@ internal sealed class GetConnectionsQueryHandler(TrackEasyDbContext dbContext) :
     {
         return await dbContext.Connections
             .Where(x => x.Operator.Id == request.OperatorId)
+            .OrderBy(x => x.Name)
             .Select(x => new ConnectionDto(
                 x.Id,
                 x.Name,

--- a/src/TrackEasy.Infrastructure/Queries/DiscountCodes/GetDiscountCodesQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/DiscountCodes/GetDiscountCodesQueryHandler.cs
@@ -16,6 +16,7 @@ internal sealed class GetDiscountCodesQueryHandler(TrackEasyDbContext dbContext)
             .AsNoTracking()
             .WithCode(request.Code)
             .WithPercentage(request.Percentage)
+            .OrderBy(x => x.Code)
             .Select(x => new DiscountCodeDto(x.Id, x.Code, x.Percentage, x.From, x.To))
             .PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);
     }

--- a/src/TrackEasy.Infrastructure/Queries/Discounts/GetDiscountsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Discounts/GetDiscountsQueryHandler.cs
@@ -16,6 +16,7 @@ internal sealed class GetDiscountsQueryHandler(TrackEasyDbContext dbContext) : I
             .AsNoTracking()
             .WithName(request.Name)
             .WithPercentage(request.Percentage)
+            .OrderBy(x => x.Name)
             .Select(x => new DiscountDto(x.Id, x.Name, x.Percentage))
             .PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);
     }

--- a/src/TrackEasy.Infrastructure/Queries/Operators/GetCoachesQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Operators/GetCoachesQueryHandler.cs
@@ -15,6 +15,7 @@ internal sealed class GetCoachesQueryHandler(TrackEasyDbContext dbContext) : IQu
             .AsNoTracking()
             .WithOperatorId(request.OperatorId)
             .WithCoachCode(request.Code)
+            .OrderBy(c => c.Code)
             .Select(c => new CoachDto(c.Id, c.Code))
             .PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);
     }

--- a/src/TrackEasy.Infrastructure/Queries/Operators/GetOperatorsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Operators/GetOperatorsQueryHandler.cs
@@ -14,6 +14,7 @@ internal sealed class GetOperatorsQueryHandler(TrackEasyDbContext dbContext) : I
         return await dbContext.Operators
             .WithName(request.Name)
             .WithCode(request.Code)
+            .OrderBy(x => x.Name)
             .Select(x => new OperatorDto(x.Id, x.Name, x.Code))
             .PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);
     }

--- a/src/TrackEasy.Infrastructure/Queries/Operators/GetTrainsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Operators/GetTrainsQueryHandler.cs
@@ -15,6 +15,7 @@ internal sealed class GetTrainsQueryHandler(TrackEasyDbContext dbContext) : IQue
             .AsNoTracking()
             .WithOperatorId(request.OperatorId)
             .WithTrainName(request.Name)
+            .OrderBy(x => x.Name)
             .Select(x => new TrainDto(x.Id, x.Name))
             .PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);
         

--- a/src/TrackEasy.Infrastructure/Queries/Stations/GetStationsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Stations/GetStationsQueryHandler.cs
@@ -18,6 +18,7 @@ internal sealed class GetStationsQueryHandler(TrackEasyDbContext dbContext)
             .Include(s => s.City)
             .WithStationName(request.StationName)
             .WithCityName(request.CityName)
+            .OrderBy(s => s.Name)
             .Select(s => new StationDto(s.Id, s.Name, s.City.Name));
 
         return await query.PaginateAsync(request.PageNumber, request.PageSize, cancellationToken);

--- a/src/TrackEasy.Infrastructure/Queries/SystemLists/GetAdminsListQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/SystemLists/GetAdminsListQueryHandler.cs
@@ -19,6 +19,7 @@ internal sealed class GetAdminsListQueryHandler(TrackEasyDbContext dbContext) : 
                 from userRole in dbContext.UserRoles
                 where userRole.RoleId == adminRoleId
                 join user in dbContext.Users on userRole.UserId equals user.Id
+                orderby user.FirstName, user.LastName
                 select new SystemListItemDto(user.Id, $"{user.FirstName} {user.LastName}")
             ).ToListAsync(cancellationToken);
     }

--- a/src/TrackEasy.Infrastructure/Queries/SystemLists/GetCitiesListQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/SystemLists/GetCitiesListQueryHandler.cs
@@ -11,6 +11,7 @@ internal sealed class GetCitiesListQueryHandler(TrackEasyDbContext dbContext) : 
     {
         return await dbContext.Cities
             .AsNoTracking()
+            .OrderBy(c => c.Name)
             .Select(c => new SystemListItemDto(c.Id, c.Name))
             .ToListAsync(cancellationToken);
     }

--- a/src/TrackEasy.Infrastructure/Queries/SystemLists/GetDiscountsListQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/SystemLists/GetDiscountsListQueryHandler.cs
@@ -11,6 +11,7 @@ internal sealed class GetDiscountsListQueryHandler(TrackEasyDbContext dbContext)
     {
         var result = await dbContext.Discounts
             .AsNoTracking()
+            .OrderBy(d => d.Name)
             .Select(d => new SystemListItemDto(d.Id, d.Name))
             .ToListAsync(cancellationToken);
 

--- a/src/TrackEasy.Infrastructure/Queries/SystemLists/GetManagersListQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/SystemLists/GetManagersListQueryHandler.cs
@@ -12,6 +12,8 @@ internal sealed class GetManagersListQueryHandler(TrackEasyDbContext dbContext) 
         var result = await dbContext.Managers
             .AsNoTracking()
             .Where(x => x.OperatorId == request.OperatorId)
+            .OrderBy(m => m.User.FirstName)
+            .ThenBy(m => m.User.LastName)
             .Select(m => new SystemListItemDto(
                 m.User.Id,
                 m.User.FirstName + " " + m.User.LastName

--- a/src/TrackEasy.Infrastructure/Queries/SystemLists/GetOperatorsListQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/SystemLists/GetOperatorsListQueryHandler.cs
@@ -11,6 +11,7 @@ namespace TrackEasy.Infrastructure.Queries.SystemLists
         {
             var result = await dbContext.Operators
                 .AsNoTracking()
+                .OrderBy(o => o.Name)
                 .Select(o => new SystemListItemDto(o.Id, o.Name))
                 .ToListAsync(cancellationToken);
 

--- a/src/TrackEasy.Infrastructure/Queries/SystemLists/GetStationsListQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/SystemLists/GetStationsListQueryHandler.cs
@@ -11,6 +11,7 @@ namespace TrackEasy.Infrastructure.Queries.SystemLists
         {
             var result = await dbContext.Stations
                 .AsNoTracking()
+                .OrderBy(s => s.Name)
                 .Select(s => new SystemListItemDto(s.Id, s.Name))
                 .ToListAsync(cancellationToken);
 

--- a/src/TrackEasy.Infrastructure/Queries/Tickets/GetTicketsQueryHandler.cs
+++ b/src/TrackEasy.Infrastructure/Queries/Tickets/GetTicketsQueryHandler.cs
@@ -15,6 +15,7 @@ internal sealed class GetTicketsQueryHandler(TrackEasyDbContext dbContext, TimeP
             .AsNoTracking()
             .WithTicketType(request.Type, timeProvider)
             .WithUserId(request.UserId)
+            .OrderByDescending(x => x.ConnectionDate)
             .Select(x => new TicketDto(
                 x.Id,
                 x.Stations.Single(s => s.SequenceNumber == 1).Name,


### PR DESCRIPTION
## Summary
- sort all paginated queries before pagination
- add alphabetical ordering in system list handlers

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bad44ffd0832a99f14176e0c4c3ce