### PR TITLE
Add train command handler integration tests

### DIFF
--- a/src/TrackEasy.IntegrationTests/Operators/AddTrainCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Operators/AddTrainCommandHandlerTests.cs
@@ -1,0 +1,43 @@
+using Shouldly;
+using TrackEasy.Application.Operators.AddCoach;
+using TrackEasy.Application.Operators.AddTrain;
+using TrackEasy.Application.Operators.CreateOperator;
+using TrackEasy.Application.Operators.FindTrain;
+using TrackEasy.Application.Operators.GetCoaches;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.IntegrationTests.Operators;
+
+public class AddTrainCommandHandlerTests(DatabaseFixture databaseFixture) : IntegrationTestBase(databaseFixture)
+{
+    [Fact]
+    public async Task AddTrain_ValidRequest_ShouldAddTrain()
+    {
+        var operatorId = await Sender.Send(new CreateOperatorCommand("Test Operator", "TO"));
+
+        await Sender.Send(new AddCoachCommand(operatorId, "C1", [1, 2]));
+        await Sender.Send(new AddCoachCommand(operatorId, "C2", [1, 2]));
+
+        var coaches = await Sender.Send(new GetCoachesQuery(operatorId, null, 1, 10));
+        var coach1 = coaches.Items.First(c => c.Code == "C1");
+        var coach2 = coaches.Items.First(c => c.Code == "C2");
+
+        var command = new AddTrainCommand(operatorId, "Express", [(coach1.Id, 1), (coach2.Id, 2)]);
+        var trainId = await Sender.Send(command);
+
+        var train = await Sender.Send(new FindTrainQuery(operatorId, trainId));
+        train.ShouldNotBeNull();
+        train!.Name.ShouldBe("Express");
+        train.Coaches.Count().ShouldBe(2);
+        train.Coaches.ShouldContain(c => c.Coach.Id == coach1.Id && c.Number == 1);
+        train.Coaches.ShouldContain(c => c.Coach.Id == coach2.Id && c.Number == 2);
+    }
+
+    [Fact]
+    public async Task AddTrain_OperatorNotFound_ShouldThrowException()
+    {
+        var command = new AddTrainCommand(Guid.NewGuid(), "Express", []);
+
+        await Assert.ThrowsAsync<TrackEasyException>(() => Sender.Send(command));
+    }
+}

--- a/src/TrackEasy.IntegrationTests/Operators/DeleteTrainCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Operators/DeleteTrainCommandHandlerTests.cs
@@ -1,0 +1,35 @@
+using TrackEasy.Application.Operators.AddCoach;
+using TrackEasy.Application.Operators.AddTrain;
+using TrackEasy.Application.Operators.CreateOperator;
+using TrackEasy.Application.Operators.DeleteTrain;
+using TrackEasy.Application.Operators.GetCoaches;
+using TrackEasy.Application.Operators.GetTrains;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.IntegrationTests.Operators;
+
+public class DeleteTrainCommandHandlerTests(DatabaseFixture databaseFixture) : IntegrationTestBase(databaseFixture)
+{
+    [Fact]
+    public async Task DeleteTrain_ValidRequest_ShouldDeleteTrain()
+    {
+        var operatorId = await Sender.Send(new CreateOperatorCommand("Test Operator", "TO"));
+        await Sender.Send(new AddCoachCommand(operatorId, "C1", [1, 2]));
+
+        var coach = (await Sender.Send(new GetCoachesQuery(operatorId, null, 1, 10))).Items.First();
+        var trainId = await Sender.Send(new AddTrainCommand(operatorId, "Express", [(coach.Id, 1)]));
+
+        await Sender.Send(new DeleteTrainCommand(trainId, operatorId));
+
+        var trains = await Sender.Send(new GetTrainsQuery(operatorId, null, 1, 10));
+        Assert.Empty(trains.Items);
+    }
+
+    [Fact]
+    public async Task DeleteTrain_OperatorNotFound_ShouldThrowException()
+    {
+        var command = new DeleteTrainCommand(Guid.NewGuid(), Guid.NewGuid());
+
+        await Assert.ThrowsAsync<TrackEasyException>(() => Sender.Send(command));
+    }
+}

--- a/src/TrackEasy.IntegrationTests/Operators/UpdateTrainCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Operators/UpdateTrainCommandHandlerTests.cs
@@ -1,0 +1,48 @@
+using Shouldly;
+using TrackEasy.Application.Operators.AddCoach;
+using TrackEasy.Application.Operators.AddTrain;
+using TrackEasy.Application.Operators.CreateOperator;
+using TrackEasy.Application.Operators.FindTrain;
+using TrackEasy.Application.Operators.GetCoaches;
+using TrackEasy.Application.Operators.UpdateTrain;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.IntegrationTests.Operators;
+
+public class UpdateTrainCommandHandlerTests(DatabaseFixture databaseFixture) : IntegrationTestBase(databaseFixture)
+{
+    [Fact]
+    public async Task UpdateTrain_ValidRequest_ShouldUpdateTrain()
+    {
+        var operatorId = await Sender.Send(new CreateOperatorCommand("Test Operator", "TO"));
+
+        await Sender.Send(new AddCoachCommand(operatorId, "C1", [1, 2]));
+        await Sender.Send(new AddCoachCommand(operatorId, "C2", [1, 2]));
+        await Sender.Send(new AddCoachCommand(operatorId, "C3", [1, 2]));
+
+        var coaches = await Sender.Send(new GetCoachesQuery(operatorId, null, 1, 10));
+        var coach1 = coaches.Items.First(c => c.Code == "C1");
+        var coach2 = coaches.Items.First(c => c.Code == "C2");
+        var coach3 = coaches.Items.First(c => c.Code == "C3");
+
+        var trainId = await Sender.Send(new AddTrainCommand(operatorId, "Express", [(coach1.Id, 1), (coach2.Id, 2)]));
+
+        var updateCommand = new UpdateTrainCommand(operatorId, trainId, "Updated", [(coach2.Id, 1), (coach3.Id, 2)]);
+        await Sender.Send(updateCommand);
+
+        var train = await Sender.Send(new FindTrainQuery(operatorId, trainId));
+        train.ShouldNotBeNull();
+        train!.Name.ShouldBe("Updated");
+        train.Coaches.Count().ShouldBe(2);
+        train.Coaches.ShouldContain(c => c.Coach.Id == coach2.Id && c.Number == 1);
+        train.Coaches.ShouldContain(c => c.Coach.Id == coach3.Id && c.Number == 2);
+    }
+
+    [Fact]
+    public async Task UpdateTrain_OperatorNotFound_ShouldThrowException()
+    {
+        var command = new UpdateTrainCommand(Guid.NewGuid(), Guid.NewGuid(), "Express", []);
+
+        await Assert.ThrowsAsync<TrackEasyException>(() => Sender.Send(command));
+    }
+}


### PR DESCRIPTION
## Summary
- add new integration tests covering train commands

## Testing
- `dotnet test` *(fails: .NET SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_684baf0910a0832a938c53afb0076c36