### PR TITLE
Add integration tests for connection handlers

### DIFF
--- a/src/TrackEasy.IntegrationTests/Connections/ApproveConnectionRequestCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Connections/ApproveConnectionRequestCommandHandlerTests.cs
@@ -1,0 +1,73 @@
+using Shouldly;
+using TrackEasy.Application.Cities.CreateCity;
+using TrackEasy.Application.Connections.ApproveConnectionRequest;
+using TrackEasy.Application.Connections.CreateConnection;
+using TrackEasy.Application.Connections.DeleteConnection;
+using TrackEasy.Application.Connections.FindConnection;
+using TrackEasy.Application.Connections.Shared;
+using TrackEasy.Application.Shared;
+using TrackEasy.Application.Operators.AddCoach;
+using TrackEasy.Application.Operators.AddTrain;
+using TrackEasy.Application.Operators.CreateOperator;
+using TrackEasy.Application.Operators.GetCoaches;
+using TrackEasy.Domain.Cities;
+using TrackEasy.Domain.Shared;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.IntegrationTests.Connections;
+
+public class ApproveConnectionRequestCommandHandlerTests(DatabaseFixture databaseFixture) : IntegrationTestBase(databaseFixture)
+{
+    private async Task<Guid> PrepareConnection()
+    {
+        var city1 = await Sender.Send(new CreateCityCommand("City1", Country.AD, []));
+        var city2 = await Sender.Send(new CreateCityCommand("City2", Country.AD, []));
+        var station1 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station1", city1, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(1,1)));
+        var station2 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station2", city2, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(2,2)));
+
+        var operatorId = await Sender.Send(new CreateOperatorCommand("Operator", "OP"));
+        await Sender.Send(new AddCoachCommand(operatorId, "C1", [1,2]));
+        var coach = (await Sender.Send(new GetCoachesQuery(operatorId, null, 1,10))).Items.First();
+        var trainId = await Sender.Send(new AddTrainCommand(operatorId, "T1", [(coach.Id,1)]));
+
+        var schedule = new ScheduleDto(new DateOnly(2025,1,1), new DateOnly(2025,12,31), [DayOfWeek.Monday]);
+        var stations = new List<ConnectionStationDto>
+        {
+            new ConnectionStationDto(station1, null, new TimeOnly(8,0), 1),
+            new ConnectionStationDto(station2, new TimeOnly(10,0), null, 2)
+        };
+        return await Sender.Send(new CreateConnectionCommand("Conn", operatorId, new MoneyDto(1, Currency.EUR), trainId, schedule, stations, true));
+    }
+
+    [Fact]
+    public async Task ApproveConnectionRequest_AddRequest_ShouldActivateConnection()
+    {
+        var id = await PrepareConnection();
+
+        await Sender.Send(new ApproveConnectionRequestCommand(id));
+
+        var connection = await Sender.Send(new FindConnectionQuery(id));
+        connection!.IsActive.ShouldBeTrue();
+        connection.HasPendingRequest.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ApproveConnectionRequest_DeleteRequest_ShouldRemoveConnection()
+    {
+        var id = await PrepareConnection();
+        await Sender.Send(new ApproveConnectionRequestCommand(id));
+        await Sender.Send(new DeleteConnectionCommand(id));
+
+        await Sender.Send(new ApproveConnectionRequestCommand(id));
+
+        var connection = await Sender.Send(new FindConnectionQuery(id));
+        connection.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ApproveConnectionRequest_NotFound_ShouldThrowException()
+    {
+        await Should.ThrowAsync<TrackEasyException>(async () =>
+            await Sender.Send(new ApproveConnectionRequestCommand(Guid.NewGuid())));
+    }
+}

--- a/src/TrackEasy.IntegrationTests/Connections/CreateConnectionCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Connections/CreateConnectionCommandHandlerTests.cs
@@ -1,0 +1,59 @@
+using Shouldly;
+using TrackEasy.Application.Cities.CreateCity;
+using TrackEasy.Application.Connections.CreateConnection;
+using TrackEasy.Application.Connections.FindConnection;
+using TrackEasy.Application.Connections.Shared;
+using TrackEasy.Application.Shared;
+using TrackEasy.Application.Operators.AddCoach;
+using TrackEasy.Application.Operators.AddTrain;
+using TrackEasy.Application.Operators.CreateOperator;
+using TrackEasy.Application.Operators.GetCoaches;
+using TrackEasy.Domain.Cities;
+using TrackEasy.Domain.Shared;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.IntegrationTests.Connections;
+
+public class CreateConnectionCommandHandlerTests(DatabaseFixture databaseFixture) : IntegrationTestBase(databaseFixture)
+{
+    [Fact]
+    public async Task CreateConnection_ValidData_ShouldCreateConnection()
+    {
+        var city1 = await Sender.Send(new CreateCityCommand("City1", Country.AD, []));
+        var city2 = await Sender.Send(new CreateCityCommand("City2", Country.AD, []));
+        var station1 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station1", city1, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(1,1)));
+        var station2 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station2", city2, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(2,2)));
+
+        var operatorId = await Sender.Send(new CreateOperatorCommand("Operator", "OP"));
+        await Sender.Send(new AddCoachCommand(operatorId, "C1", [1,2]));
+        var coach = (await Sender.Send(new GetCoachesQuery(operatorId, null, 1,10))).Items.First();
+        var trainId = await Sender.Send(new AddTrainCommand(operatorId, "T1", [(coach.Id,1)]));
+
+        var schedule = new ScheduleDto(new DateOnly(2025,1,1), new DateOnly(2025,12,31), [DayOfWeek.Monday]);
+        var stations = new List<ConnectionStationDto>
+        {
+            new ConnectionStationDto(station1, null, new TimeOnly(8,0), 1),
+            new ConnectionStationDto(station2, new TimeOnly(10,0), null, 2)
+        };
+        var command = new CreateConnectionCommand("Conn", operatorId, new MoneyDto(1, Currency.EUR), trainId, schedule, stations, true);
+
+        var id = await Sender.Send(command);
+
+        var connection = await Sender.Send(new FindConnectionQuery(id));
+        connection.ShouldNotBeNull();
+        connection!.Name.ShouldBe("Conn");
+        connection.TrainName.ShouldBe("T1");
+        connection.Stations.Count().ShouldBe(2);
+        connection.HasPendingRequest.ShouldBeTrue();
+        connection.IsActive.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CreateConnection_OperatorNotFound_ShouldThrowException()
+    {
+        var schedule = new ScheduleDto(new DateOnly(2025,1,1), new DateOnly(2025,12,31), [DayOfWeek.Monday]);
+        var command = new CreateConnectionCommand("Conn", Guid.NewGuid(), new MoneyDto(1, Currency.EUR), Guid.NewGuid(), schedule, new List<ConnectionStationDto>(), true);
+
+        await Should.ThrowAsync<TrackEasyException>(async () => await Sender.Send(command));
+    }
+}

--- a/src/TrackEasy.IntegrationTests/Connections/DeleteConnectionCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Connections/DeleteConnectionCommandHandlerTests.cs
@@ -1,0 +1,63 @@
+using Shouldly;
+using TrackEasy.Application.Cities.CreateCity;
+using TrackEasy.Application.Connections.ApproveConnectionRequest;
+using TrackEasy.Application.Connections.CreateConnection;
+using TrackEasy.Application.Connections.DeleteConnection;
+using TrackEasy.Application.Connections.FindConnectionChangeRequest;
+using TrackEasy.Application.Connections.Shared;
+using TrackEasy.Application.Shared;
+using TrackEasy.Domain.Connections;
+using TrackEasy.Application.Operators.AddCoach;
+using TrackEasy.Application.Operators.AddTrain;
+using TrackEasy.Application.Operators.CreateOperator;
+using TrackEasy.Application.Operators.GetCoaches;
+using TrackEasy.Domain.Cities;
+using TrackEasy.Domain.Shared;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.IntegrationTests.Connections;
+
+public class DeleteConnectionCommandHandlerTests(DatabaseFixture databaseFixture) : IntegrationTestBase(databaseFixture)
+{
+    private async Task<Guid> PrepareActiveConnection()
+    {
+        var city1 = await Sender.Send(new CreateCityCommand("City1", Country.AD, []));
+        var city2 = await Sender.Send(new CreateCityCommand("City2", Country.AD, []));
+        var station1 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station1", city1, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(1,1)));
+        var station2 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station2", city2, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(2,2)));
+
+        var operatorId = await Sender.Send(new CreateOperatorCommand("Operator", "OP"));
+        await Sender.Send(new AddCoachCommand(operatorId, "C1", [1,2]));
+        var coach = (await Sender.Send(new GetCoachesQuery(operatorId, null, 1,10))).Items.First();
+        var trainId = await Sender.Send(new AddTrainCommand(operatorId, "T1", [(coach.Id,1)]));
+
+        var schedule = new ScheduleDto(new DateOnly(2025,1,1), new DateOnly(2025,12,31), [DayOfWeek.Monday]);
+        var stations = new List<ConnectionStationDto>
+        {
+            new ConnectionStationDto(station1, null, new TimeOnly(8,0), 1),
+            new ConnectionStationDto(station2, new TimeOnly(10,0), null, 2)
+        };
+        var id = await Sender.Send(new CreateConnectionCommand("Conn", operatorId, new MoneyDto(1, Currency.EUR), trainId, schedule, stations, true));
+        await Sender.Send(new ApproveConnectionRequestCommand(id));
+        return id;
+    }
+
+    [Fact]
+    public async Task DeleteConnection_ValidRequest_ShouldCreateDeleteRequest()
+    {
+        var id = await PrepareActiveConnection();
+
+        await Sender.Send(new DeleteConnectionCommand(id));
+
+        var request = await Sender.Send(new FindConnectionChangeRequestQuery(id));
+        request.ShouldNotBeNull();
+        request!.RequestType.ShouldBe(ConnectionRequestType.DELETE);
+    }
+
+    [Fact]
+    public async Task DeleteConnection_NotFound_ShouldThrowException()
+    {
+        await Should.ThrowAsync<TrackEasyException>(async () =>
+            await Sender.Send(new DeleteConnectionCommand(Guid.NewGuid())));
+    }
+}

--- a/src/TrackEasy.IntegrationTests/Connections/RejectConnectionRequestCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Connections/RejectConnectionRequestCommandHandlerTests.cs
@@ -1,0 +1,58 @@
+using Shouldly;
+using TrackEasy.Application.Cities.CreateCity;
+using TrackEasy.Application.Connections.CreateConnection;
+using TrackEasy.Application.Connections.RejectConnectionRequest;
+using TrackEasy.Application.Connections.FindConnection;
+using TrackEasy.Application.Connections.Shared;
+using TrackEasy.Application.Shared;
+using TrackEasy.Application.Operators.AddCoach;
+using TrackEasy.Application.Operators.AddTrain;
+using TrackEasy.Application.Operators.CreateOperator;
+using TrackEasy.Application.Operators.GetCoaches;
+using TrackEasy.Domain.Cities;
+using TrackEasy.Domain.Shared;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.IntegrationTests.Connections;
+
+public class RejectConnectionRequestCommandHandlerTests(DatabaseFixture databaseFixture) : IntegrationTestBase(databaseFixture)
+{
+    private async Task<Guid> PrepareConnection()
+    {
+        var city1 = await Sender.Send(new CreateCityCommand("City1", Country.AD, []));
+        var city2 = await Sender.Send(new CreateCityCommand("City2", Country.AD, []));
+        var station1 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station1", city1, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(1,1)));
+        var station2 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station2", city2, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(2,2)));
+
+        var operatorId = await Sender.Send(new CreateOperatorCommand("Operator", "OP"));
+        await Sender.Send(new AddCoachCommand(operatorId, "C1", [1,2]));
+        var coach = (await Sender.Send(new GetCoachesQuery(operatorId, null, 1,10))).Items.First();
+        var trainId = await Sender.Send(new AddTrainCommand(operatorId, "T1", [(coach.Id,1)]));
+
+        var schedule = new ScheduleDto(new DateOnly(2025,1,1), new DateOnly(2025,12,31), [DayOfWeek.Monday]);
+        var stations = new List<ConnectionStationDto>
+        {
+            new ConnectionStationDto(station1, null, new TimeOnly(8,0), 1),
+            new ConnectionStationDto(station2, new TimeOnly(10,0), null, 2)
+        };
+        return await Sender.Send(new CreateConnectionCommand("Conn", operatorId, new MoneyDto(1, Currency.EUR), trainId, schedule, stations, true));
+    }
+
+    [Fact]
+    public async Task RejectConnectionRequest_AddRequest_ShouldDeleteConnection()
+    {
+        var id = await PrepareConnection();
+
+        await Sender.Send(new RejectConnectionRequestCommand(id));
+
+        var connection = await Sender.Send(new FindConnectionQuery(id));
+        connection.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RejectConnectionRequest_NotFound_ShouldThrowException()
+    {
+        await Should.ThrowAsync<TrackEasyException>(async () =>
+            await Sender.Send(new RejectConnectionRequestCommand(Guid.NewGuid())));
+    }
+}

--- a/src/TrackEasy.IntegrationTests/Connections/UpdateConnectionCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Connections/UpdateConnectionCommandHandlerTests.cs
@@ -1,0 +1,62 @@
+using Shouldly;
+using TrackEasy.Application.Cities.CreateCity;
+using TrackEasy.Application.Connections.CreateConnection;
+using TrackEasy.Application.Connections.FindConnection;
+using TrackEasy.Application.Connections.Shared;
+using TrackEasy.Application.Shared;
+using TrackEasy.Application.Connections.UpdateConnection;
+using TrackEasy.Application.Operators.AddCoach;
+using TrackEasy.Application.Operators.AddTrain;
+using TrackEasy.Application.Operators.CreateOperator;
+using TrackEasy.Application.Operators.GetCoaches;
+using TrackEasy.Domain.Cities;
+using TrackEasy.Domain.Shared;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.IntegrationTests.Connections;
+
+public class UpdateConnectionCommandHandlerTests(DatabaseFixture databaseFixture) : IntegrationTestBase(databaseFixture)
+{
+    private async Task<Guid> PrepareConnection()
+    {
+        var city1 = await Sender.Send(new CreateCityCommand("City1", Country.AD, []));
+        var city2 = await Sender.Send(new CreateCityCommand("City2", Country.AD, []));
+        var station1 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station1", city1, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(1,1)));
+        var station2 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station2", city2, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(2,2)));
+
+        var operatorId = await Sender.Send(new CreateOperatorCommand("Operator", "OP"));
+        await Sender.Send(new AddCoachCommand(operatorId, "C1", [1,2]));
+        var coach = (await Sender.Send(new GetCoachesQuery(operatorId, null, 1,10))).Items.First();
+        var trainId = await Sender.Send(new AddTrainCommand(operatorId, "T1", [(coach.Id,1)]));
+
+        var schedule = new ScheduleDto(new DateOnly(2025,1,1), new DateOnly(2025,12,31), [DayOfWeek.Monday]);
+        var stations = new List<ConnectionStationDto>
+        {
+            new ConnectionStationDto(station1, null, new TimeOnly(8,0), 1),
+            new ConnectionStationDto(station2, new TimeOnly(10,0), null, 2)
+        };
+        var command = new CreateConnectionCommand("Conn", operatorId, new MoneyDto(1, Currency.EUR), trainId, schedule, stations, true);
+        return await Sender.Send(command);
+    }
+
+    [Fact]
+    public async Task UpdateConnection_ValidData_ShouldUpdateConnection()
+    {
+        var id = await PrepareConnection();
+
+        var command = new UpdateConnectionCommand(id, "Updated", new MoneyDto(2, Currency.EUR));
+        await Sender.Send(command);
+
+        var connection = await Sender.Send(new FindConnectionQuery(id));
+        connection!.Name.ShouldBe("Updated");
+        connection.PricePerKilometer.Amount.ShouldBe(2);
+        connection.PricePerKilometer.Currency.ShouldBe(Currency.EUR);
+    }
+
+    [Fact]
+    public async Task UpdateConnection_NotFound_ShouldThrowException()
+    {
+        var command = new UpdateConnectionCommand(Guid.NewGuid(), "Updated", new MoneyDto(2, Currency.EUR));
+        await Should.ThrowAsync<TrackEasyException>(async () => await Sender.Send(command));
+    }
+}

--- a/src/TrackEasy.IntegrationTests/Connections/UpdateScheduleCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Connections/UpdateScheduleCommandHandlerTests.cs
@@ -1,0 +1,67 @@
+using Shouldly;
+using TrackEasy.Application.Cities.CreateCity;
+using TrackEasy.Application.Connections.ApproveConnectionRequest;
+using TrackEasy.Application.Connections.CreateConnection;
+using TrackEasy.Application.Connections.FindConnectionChangeRequest;
+using TrackEasy.Application.Connections.Shared;
+using TrackEasy.Application.Shared;
+using TrackEasy.Domain.Connections;
+using TrackEasy.Application.Connections.UpdateSchedule;
+using TrackEasy.Application.Operators.AddCoach;
+using TrackEasy.Application.Operators.AddTrain;
+using TrackEasy.Application.Operators.CreateOperator;
+using TrackEasy.Application.Operators.GetCoaches;
+using TrackEasy.Domain.Cities;
+using TrackEasy.Domain.Shared;
+using TrackEasy.Shared.Exceptions;
+
+namespace TrackEasy.IntegrationTests.Connections;
+
+public class UpdateScheduleCommandHandlerTests(DatabaseFixture databaseFixture) : IntegrationTestBase(databaseFixture)
+{
+    private async Task<Guid> PrepareActiveConnection()
+    {
+        var city1 = await Sender.Send(new CreateCityCommand("City1", Country.AD, []));
+        var city2 = await Sender.Send(new CreateCityCommand("City2", Country.AD, []));
+        var station1 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station1", city1, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(1,1)));
+        var station2 = await Sender.Send(new TrackEasy.Application.Stations.CreateStation.CreateStationCommand("Station2", city2, new TrackEasy.Application.Stations.Shared.GeographicalCoordinatesDto(2,2)));
+
+        var operatorId = await Sender.Send(new CreateOperatorCommand("Operator", "OP"));
+        await Sender.Send(new AddCoachCommand(operatorId, "C1", [1,2]));
+        var coach = (await Sender.Send(new GetCoachesQuery(operatorId, null, 1,10))).Items.First();
+        var trainId = await Sender.Send(new AddTrainCommand(operatorId, "T1", [(coach.Id,1)]));
+
+        var schedule = new ScheduleDto(new DateOnly(2025,1,1), new DateOnly(2025,12,31), [DayOfWeek.Monday]);
+        var stations = new List<ConnectionStationDto>
+        {
+            new ConnectionStationDto(station1, null, new TimeOnly(8,0), 1),
+            new ConnectionStationDto(station2, new TimeOnly(10,0), null, 2)
+        };
+        var id = await Sender.Send(new CreateConnectionCommand("Conn", operatorId, new MoneyDto(1, Currency.EUR), trainId, schedule, stations, true));
+        await Sender.Send(new ApproveConnectionRequestCommand(id));
+        return id;
+    }
+
+    [Fact]
+    public async Task UpdateSchedule_ValidRequest_ShouldCreateUpdateRequest()
+    {
+        var id = await PrepareActiveConnection();
+
+        var schedule = new ScheduleDto(new DateOnly(2025,2,1), new DateOnly(2025,12,31), [DayOfWeek.Tuesday]);
+        var request = new UpdateScheduleCommand(id, schedule, new List<ConnectionStationDto>());
+        await Sender.Send(request);
+
+        var changeRequest = await Sender.Send(new FindConnectionChangeRequestQuery(id));
+        changeRequest.ShouldNotBeNull();
+        changeRequest!.RequestType.ShouldBe(ConnectionRequestType.UPDATE);
+        changeRequest.Schedule!.ValidFrom.ShouldBe(schedule.ValidFrom);
+    }
+
+    [Fact]
+    public async Task UpdateSchedule_NotFound_ShouldThrowException()
+    {
+        var schedule = new ScheduleDto(new DateOnly(2025,2,1), new DateOnly(2025,12,31), [DayOfWeek.Tuesday]);
+        await Should.ThrowAsync<TrackEasyException>(async () =>
+            await Sender.Send(new UpdateScheduleCommand(Guid.NewGuid(), schedule, new List<ConnectionStationDto>())));
+    }
+}

--- a/src/TrackEasy.IntegrationTests/Stations/CreateStationCommandHandlerTests.cs
+++ b/src/TrackEasy.IntegrationTests/Stations/CreateStationCommandHandlerTests.cs
@@ -23,7 +23,7 @@ public class CreateStationCommandHandlerTests(DatabaseFixture databaseFixture) :
         var station = await Sender.Send(new FindStationQuery(stationId));
         station.ShouldNotBeNull();
         station!.Name.ShouldBe("Test");
-        station.City.ShouldBe("Test City");
+        station.CityName.ShouldBe("Test City");
         station.GeographicalCoordinates.Latitude.ShouldBe(62.2M);
         station.GeographicalCoordinates.Longitude.ShouldBe(48.8M);
     }


### PR DESCRIPTION
## Summary
- add integration tests covering connection command handlers
- fix station test to use `CityName` property

## Testing
- `dotnet build`
- `dotnet test --no-build --verbosity minimal` *(fails: Docker is not running)*

------
https://chatgpt.com/codex/tasks/task_e_684bb5e1b838832abbab013474b1750a