### PR TITLE
Fix sign out for internal users

### DIFF
--- a/src/TrackEasy.Infrastructure/Extensions.cs
+++ b/src/TrackEasy.Infrastructure/Extensions.cs
@@ -59,6 +59,7 @@ public static class Extensions
             options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
             options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
         })
+        .AddCookie(IdentityConstants.ApplicationScheme)
         .AddCookie(IdentityConstants.ExternalScheme)
         .AddJwtBearer(options =>
         {


### PR DESCRIPTION
## Summary
- register Identity application cookie

## Testing
- `dotnet test src/TrackEasy.UnitTests/TrackEasy.UnitTests.csproj -v n` *(fails: NETSDK1045 targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_684bd73080ec832ab7562493db406b6f