### PR TITLE
Remove local card validation for Stripe payments

### DIFF
--- a/src/TrackEasy.Application/Tickets/PayTicketByCard/PayTicketByCardCommandHandler.cs
+++ b/src/TrackEasy.Application/Tickets/PayTicketByCard/PayTicketByCardCommandHandler.cs
@@ -50,7 +50,7 @@ internal sealed class PayTicketByCardCommandHandler(
         var paymentMethodOps = new PaymentMethodCreateOptions
         {
             Type = "card",
-            Card = new PaymentMethodCardCreateOptions
+            Card = new PaymentMethodCardOptions
             {
                 Number = request.CardNumber,
                 ExpMonth = request.CardExpMonth,
@@ -59,7 +59,7 @@ internal sealed class PayTicketByCardCommandHandler(
             }
         };
 
-        PaymentMethod paymentMethod;
+        Stripe.PaymentMethod paymentMethod;
         try
         {
             paymentMethod = await _paymentMethodService.CreateAsync(paymentMethodOps, cancellationToken: cancellationToken);


### PR DESCRIPTION
## Summary
- create payment method on Stripe using provided card details
- remove manual card validation logic

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test TrackEasy.sln` *(fails: NETSDK1045: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6853b001c4f8832a9f498399c4dfe1e7