### PR TITLE
Fix external login challenge

### DIFF
--- a/src/TrackEasy.Api/Endpoints/UserEndpoints.cs
+++ b/src/TrackEasy.Api/Endpoints/UserEndpoints.cs
@@ -107,10 +107,10 @@ public class UserEndpoints : IEndpoints
             .WithDescription("Generate reset password token.")
             .WithOpenApi();
 
-        group.MapGet("/external/{provider}", (string provider, string firstName, string lastName, DateOnly dateOfBirth, HttpContext httpContext) =>
+        group.MapGet("/external/{provider}", (string provider, string firstName, string lastName, DateOnly dateOfBirth, SignInManager<User> signInManager) =>
         {
             var redirectUrl = $"/users/external/{provider}/callback";
-            var properties = new AuthenticationProperties { RedirectUri = redirectUrl };
+            var properties = signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl);
             properties.Items["firstName"] = firstName;
             properties.Items["lastName"] = lastName;
             properties.Items["dob"] = dateOfBirth.ToString("O");


### PR DESCRIPTION
## Summary
- fix login via Google and Microsoft by using ConfigureExternalAuthenticationProperties

## Testing
- `dotnet test src/TrackEasy.UnitTests/TrackEasy.UnitTests.csproj -v minimal` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6853b33dc458832abce67d49101fdc86